### PR TITLE
SideSheet, add prop position

### DIFF
--- a/src/components/SideSheet.vue
+++ b/src/components/SideSheet.vue
@@ -9,7 +9,7 @@
 			>
 				<div
 					class="container px-0"
-					:class="floatClass"
+					:class="position"
 					@click.stop
 				>
 					<!-- @slot Slot usado para customizar o botão de fechamento do SideSheet. -->
@@ -48,21 +48,14 @@ export default {
 			type: Boolean,
 			default: false,
 			required: true,
-		},
-		/**
-		 * Define se o SideSheet vai ser mostrado no canto direito. Situação padrão.
+    },
+    /**
+		 * Define a posição ao qual o SideSheet será mostrado.
 		 */
-		right: {
-			type: Boolean,
-			default: false,
-		},
-		/**
-		 * Define se o SideSheet vai ser mostrado no canto esquerdo.
-		 */
-		left: {
-			type: Boolean,
-			default: false,
-		},
+    position: {
+      type: String,
+      default: 'right',
+    },
 		/**
 		 * Define se o SideSheet vai ser fechado com o click no backdrop.
 		 */
@@ -80,20 +73,8 @@ export default {
 	},
 
 	computed: {
-		floatClass() {
-			if (this.left) {
-				return 'left';
-			}
-
-			return 'right';
-		},
-
 		floatTransition() {
-			if (this.left) {
-				return 'slide-fade-left';
-			}
-
-			return 'slide-fade-right';
+			return `slide-fade-${this.position}`;
 		},
 	},
 

--- a/src/stories/SideSheet.stories.mdx
+++ b/src/stories/SideSheet.stories.mdx
@@ -74,7 +74,7 @@ export const Template = (args, { argTypes }) => ({
 	<Story
 		name="SideSheet"
 		args={{
-			position: right,
+			position: 'right',
 			noCloseOnBackdrop: false,
 			noCloseOnEsc: false,
 		}}

--- a/src/stories/SideSheet.stories.mdx
+++ b/src/stories/SideSheet.stories.mdx
@@ -4,6 +4,14 @@ import SideSheet from '../components/SideSheet.vue';
 <Meta
 	title="Componentes/SideSheet"
 	component={ SideSheet }
+	argTypes={{
+		position: {
+			control: {
+				type: 'select',
+				options: ['right', 'left']
+			}
+		},
+	}}
 />
 
 export const Template = (args, { argTypes }) => ({
@@ -26,11 +34,11 @@ export const Template = (args, { argTypes }) => ({
 				v-bind="$props"
 			>
 				<p class="p-3">
-					Mussum Ipsum, cacilds vidis litro abertis. Todo mundo 
+					Mussum Ipsum, cacilds vidis litro abertis. Todo mundo
 					vê os porris que eu tomo, mas ninguém vê os tombis que eu levo!
 					Atirei o pau no gatis, per gatis num morreus. Pra lá , depois
 					divoltis porris, paradis. Leite de capivaris, leite de mula
-					manquis sem cabeça. Viva Forevis aptent taciti sociosqu ad 
+					manquis sem cabeça. Viva Forevis aptent taciti sociosqu ad
 					litora torquent. Per aumento de cachacis, eu reclamis. Nec
 					orci ornare consequat. Praesent lacinia ultrices consectetur.
 					Sed non ipsum felis. Cevadis im ampola pa arma uma pindureta.
@@ -66,8 +74,7 @@ export const Template = (args, { argTypes }) => ({
 	<Story
 		name="SideSheet"
 		args={{
-			right: false,
-			left: false,
+			position: right,
 			noCloseOnBackdrop: false,
 			noCloseOnEsc: false,
 		}}

--- a/tests/unit/SideSheet.spec.js
+++ b/tests/unit/SideSheet.spec.js
@@ -10,7 +10,7 @@ test('Component is mounted properly', () => {
 		localVue,
 		propsData: {
 			value: true,
-			right: true,
+			position: 'right',
 		},
 	});
 	expect(wrapper).toMatchSnapshot();
@@ -22,7 +22,7 @@ describe("Items styles test", () => {
 			localVue,
 			propsData: {
 				value: true,
-				left: true,
+				position: 'left',
 			},
 		});
 		expect(wrapper.findAll('.left').length).toBe(1);
@@ -33,11 +33,21 @@ describe("Items styles test", () => {
 			localVue,
 			propsData: {
 				value: true,
-				right: true,
+				position: 'right',
 			},
 		});
 		expect(wrapper.findAll('.right').length).toBe(1);
-	});
+  });
+
+  test('if content is right aligned by default', () => {
+    const wrapper = mount(SideSheet, {
+      localVue,
+      propsData: {
+        value: true,
+      },
+    });
+    expect(wrapper.findAll('.right').length).toBe(1);
+  });
 });
 
 describe("Behavior tests", () => {
@@ -47,7 +57,7 @@ describe("Behavior tests", () => {
 			localVue,
 			propsData: {
 				value: true,
-				right: true,
+				position: 'right',
 				noCloseOnBackdrop: true,
 			},
 		});
@@ -64,7 +74,7 @@ describe("Behavior tests", () => {
 			localVue,
 			propsData: {
 				value: true,
-				right: true,
+				position: 'right',
 				noCloseOnEsc: true,
 			},
 		});


### PR DESCRIPTION
Issue #37 

O posicionamento do componente SideSheet passar a ser controlado pela prop `position: right|left`.

As propriedades `right` e `left` foram removidas.