### PR TITLE
Coloca tag svg direto no component para contornar falha no build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sysvale/cuida",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A design system built by Sysvale, using storybook and Vue components",
   "repository": {
     "type": "git",

--- a/src/components/Stepper.vue
+++ b/src/components/Stepper.vue
@@ -40,11 +40,14 @@
 						v-else-if="step.error"
 						size="1x"
 					/>
-					<img
+					<div
 						v-else-if="step.inProcessing"
-						class="ml-n-1px"
-						src="../assets/images/in-processing.svg"
-					/>
+						class="ml-n-1px d-flex align-items-center"
+					>
+						<svg width="19" height="22" viewBox="0 0 19 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+							<path d="M18.78 16.6325C17.738 18.0472 16.3457 19.1664 14.7402 19.8799C13.1346 20.5935 11.3709 20.8769 9.62259 20.7023C7.87428 20.5276 6.20151 19.901 4.76877 18.884C3.33604 17.867 2.19266 16.4945 1.45107 14.9017C0.709475 13.3089 0.395207 11.5504 0.539162 9.79934C0.683116 8.04824 1.28034 6.36474 2.2721 4.9144C3.26387 3.46406 4.61603 2.2968 6.19562 1.52741C7.77522 0.758019 9.52787 0.412981 11.2812 0.526225L10.6287 10.6288L18.78 16.6325Z" fill="#3A7EDF"/>
+						</svg>
+					</div>
 					<span
 						v-else
 						class="fs-14"
@@ -74,7 +77,7 @@
 	</div>
 </template>
 <script>
-import { CheckIcon, XIcon } from 'vue-feather-icons'
+import { CheckIcon, XIcon } from 'vue-feather-icons';
 
 export default {
 	components: {

--- a/src/components/UploadInput.vue
+++ b/src/components/UploadInput.vue
@@ -18,7 +18,12 @@
 				ref="fileInput"
 			/>
 			<div v-if="!file">
-				<img src="../assets/images/upload-icon.svg"/>
+				<svg width="103" height="96" viewBox="0 0 103 96" fill="none" xmlns="http://www.w3.org/2000/svg">
+					<path d="M43.6196 87.2393C67.7101 87.2393 87.2393 67.7101 87.2393 43.6196C87.2393 19.5292 67.7101 0 43.6196 0C19.5292 0 0 19.5292 0 43.6196C0 67.7101 19.5292 87.2393 43.6196 87.2393Z" fill="#F0F5FF"/>
+					<path d="M56.6196 93.2393C80.7101 93.2393 100.239 73.7101 100.239 49.6196C100.239 25.5292 80.7101 6 56.6196 6C32.5292 6 13 25.5292 13 49.6196C13 73.7101 32.5292 93.2393 56.6196 93.2393Z" stroke="#3A7EDF" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+					<path d="M74.0675 49.6196L56.6196 32.1718L39.1718 49.6196" stroke="#3A7EDF" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+					<path d="M56.6196 67.0675V32.1718" stroke="#3A7EDF" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+				</svg>
 				<div class="mt-3 upload-input__title">
 					<div v-if="!isOnDragEnterState">
 						Arraste o arquivo aqui ou
@@ -36,7 +41,15 @@
 				</div>
 			</div>
 			<div v-else>
-				<img src="../assets/images/file-icon.svg"/>
+				<svg width="103" height="96" viewBox="0 0 103 96" fill="none" xmlns="http://www.w3.org/2000/svg">
+					<path d="M43.6196 87.2393C67.7101 87.2393 87.2393 67.7101 87.2393 43.6196C87.2393 19.5292 67.7101 0 43.6196 0C19.5292 0 0 19.5292 0 43.6196C0 67.7101 19.5292 87.2393 43.6196 87.2393Z" fill="#F0F5FF"/>
+					<path d="M56.6196 93.2393C80.7101 93.2393 100.239 73.7101 100.239 49.6196C100.239 25.5292 80.7101 6 56.6196 6C32.5292 6 13 25.5292 13 49.6196C13 73.7101 32.5292 93.2393 56.6196 93.2393Z" stroke="#3A7EDF" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+					<path d="M45 70.5H69C72.032 70.5 74.5 68.0343 74.5 65V35C74.5 31.9657 72.032 29.5 69 29.5H45C41.968 29.5 39.5 31.9657 39.5 35V65C39.5 68.0343 41.968 70.5 45 70.5ZM42.5 35C42.5 33.6221 43.6221 32.5 45 32.5H69C70.3779 32.5 71.5 33.6221 71.5 35V65C71.5 66.3779 70.3779 67.5 69 67.5H45C43.6221 67.5 42.5 66.3779 42.5 65V35Z" fill="#3A7EDF" stroke="#3A7EDF"/>
+					<path d="M49 56.5H65C65.8281 56.5 66.5 55.8281 66.5 55C66.5 54.1719 65.8281 53.5 65 53.5H49C48.1719 53.5 47.5 54.1719 47.5 55C47.5 55.8281 48.1719 56.5 49 56.5Z" fill="#3A7EDF" stroke="#3A7EDF"/>
+					<path d="M49 64.5H65C65.8281 64.5 66.5 63.8281 66.5 63C66.5 62.1719 65.8281 61.5 65 61.5H49C48.1719 61.5 47.5 62.1719 47.5 63C47.5 63.8281 48.1719 64.5 49 64.5Z" fill="#3A7EDF" stroke="#3A7EDF"/>
+					<path d="M49 48.5H65C65.8281 48.5 66.5 47.8281 66.5 47C66.5 46.1719 65.8281 45.5 65 45.5H49C48.1719 45.5 47.5 46.1719 47.5 47C47.5 47.8281 48.1719 48.5 49 48.5Z" fill="#3A7EDF" stroke="#3A7EDF"/>
+					<path d="M49 40.5H65C65.8281 40.5 66.5 39.8281 66.5 39C66.5 38.1719 65.8281 37.5 65 37.5H49C48.1719 37.5 47.5 38.1719 47.5 39C47.5 39.8281 48.1719 40.5 49 40.5Z" fill="#3A7EDF" stroke="#3A7EDF"/>
+				</svg>
 				<div class="mt-3 upload-input__title">
 					<div v-if="!isOnDragEnterState">
 						<div>{{ file.name }}</div>
@@ -128,7 +141,7 @@ export default {
 
 
 .upload-input {
-  border: 2px dashed $cinza-4;
+	border: 2px dashed $cinza-4;
 	border-radius: 16px;
 	box-sizing: border-box;
 

--- a/tests/unit/__snapshots__/Stepper.spec.js.snap
+++ b/tests/unit/__snapshots__/Stepper.spec.js.snap
@@ -20,7 +20,11 @@ exports[`Component is mounted properly 1`] = `
   <div class="w-100 ">
     <!---->
     <div id="step-2" class="d-flex align-items-center">
-      <div class="d-flex justify-content-center align-items-center cursor-pointer stepper__step--in-processing"><img src="../assets/images/in-processing.svg" class="ml-n-1px"></div>
+      <div class="d-flex justify-content-center align-items-center cursor-pointer stepper__step--in-processing">
+        <div class="ml-n-1px d-flex align-items-center"><svg width="19" height="22" viewBox="0 0 19 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M18.78 16.6325C17.738 18.0472 16.3457 19.1664 14.7402 19.8799C13.1346 20.5935 11.3709 20.8769 9.62259 20.7023C7.87428 20.5276 6.20151 19.901 4.76877 18.884C3.33604 17.867 2.19266 16.4945 1.45107 14.9017C0.709475 13.3089 0.395207 11.5504 0.539162 9.79934C0.683116 8.04824 1.28034 6.36474 2.2721 4.9144C3.26387 3.46406 4.61603 2.2968 6.19562 1.52741C7.77522 0.758019 9.52787 0.412981 11.2812 0.526225L10.6287 10.6288L18.78 16.6325Z" fill="#3A7EDF"></path>
+          </svg></div>
+      </div>
       <div class="stepper__divider--default"></div>
     </div>
     <div class="stepper__step-label stepper__step-label--muted label-max-width"><small>Dummy label 3</small></div>

--- a/tests/unit/__snapshots__/UploadInput.spec.js.snap
+++ b/tests/unit/__snapshots__/UploadInput.spec.js.snap
@@ -4,7 +4,12 @@ exports[`Component is mounted properly 1`] = `
 <div class="upload-input text-center py-3 px-5">
   <div class="text-center px-3 py-5">
     <div class="custom-file b-form-file" style="display: none;"><input type="file" class="custom-file-input" style="z-index: -5;"><label data-browse="Browse" class="custom-file-label"><span class="d-block form-file-text" style="pointer-events: none;">No file chosen</span></label></div>
-    <div><img src="../assets/images/upload-icon.svg">
+    <div><svg width="103" height="96" viewBox="0 0 103 96" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M43.6196 87.2393C67.7101 87.2393 87.2393 67.7101 87.2393 43.6196C87.2393 19.5292 67.7101 0 43.6196 0C19.5292 0 0 19.5292 0 43.6196C0 67.7101 19.5292 87.2393 43.6196 87.2393Z" fill="#F0F5FF"></path>
+        <path d="M56.6196 93.2393C80.7101 93.2393 100.239 73.7101 100.239 49.6196C100.239 25.5292 80.7101 6 56.6196 6C32.5292 6 13 25.5292 13 49.6196C13 73.7101 32.5292 93.2393 56.6196 93.2393Z" stroke="#3A7EDF" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"></path>
+        <path d="M74.0675 49.6196L56.6196 32.1718L39.1718 49.6196" stroke="#3A7EDF" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"></path>
+        <path d="M56.6196 67.0675V32.1718" stroke="#3A7EDF" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"></path>
+      </svg>
       <div class="mt-3 upload-input__title">
         <div>
           Arraste o arquivo aqui ou


### PR DESCRIPTION
O `npm run build` estava dando problema pois não conseguia resolver o `import` relativo das imagens

Para resolver o problema, temporariamente se botou os códigos svg chumbado no código do componente para não atrapalhar o fluxo das atividades dependentes. Para o problema dos `import` relativo será aberto uma issue.