### PR TITLE
Hotfix/remove v html status item

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sysvale/cuida",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "A design system built by Sysvale, using storybook and Vue components",
   "repository": {
     "type": "git",

--- a/src/components/StatusItem.vue
+++ b/src/components/StatusItem.vue
@@ -63,7 +63,6 @@
 						-->
 						<span
 							:class="clickableAlert ? 'alert--clickable' : ''"
-							v-html="alertText"
 							@click="clickableAlert ? $emit('alert-clicked') : ''"
 						>
 							<!--

--- a/src/stories/StatusItem.stories.mdx
+++ b/src/stories/StatusItem.stories.mdx
@@ -57,7 +57,6 @@ export const Template = (args, { argTypes }) => ({
 			clickableAction: true,
 			actionText: 'Download',
 			actionSubtitle: 'Último download em 00/00/0000 00:00',
-			alertText: 'Lote inconsistente, <strong>clique aqui</strong> para saber como resolver.',
 		}}
 	>
 		{ Template.bind({}) }


### PR DESCRIPTION
- Corrige problema em que, ao utilizar o slot `alertText` do componente `StatusItem`, o texto não era renderizado na tela.