### PR TITLE
hotfix/stepper-input-unselectble-buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sysvale/cuida",
-  "version": "1.9.10",
+  "version": "1.9.11",
   "description": "A design system built by Sysvale, using storybook and Vue components",
   "repository": {
     "type": "git",

--- a/src/components/StepperInput.vue
+++ b/src/components/StepperInput.vue
@@ -20,6 +20,7 @@
 					@click="changeValue(1)"
 					v-longclick="() => changeValue(1)"
 					class="stepper-input__icon--plus"
+					tabindex="-1"
 				>
 					<plus-icon size="1x" class="custom-class" />
 				</button>
@@ -31,6 +32,7 @@
 					@click="changeValue(-1)"
 					v-longclick="() => changeValue(-1)"
 					class="stepper-input__icon--minus"
+					tabindex="-1"
 				>
 					<minus-icon size="1x" class="custom-class" />
 				</button>

--- a/tests/unit/__snapshots__/StepperInput.spec.js.snap
+++ b/tests/unit/__snapshots__/StepperInput.spec.js.snap
@@ -3,10 +3,10 @@
 exports[`Component is mounted properly 1`] = `
 <div><label for="stepper-input-number">Label</label>
   <div class="stepper-input"><input id="stepper-input-number" type="number" class="stepper-input__field">
-    <div class="stepper-input__icon-container"><button class="stepper-input__icon--plus"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="custom-class feather feather-plus">
+    <div class="stepper-input__icon-container"><button tabindex="-1" class="stepper-input__icon--plus"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="custom-class feather feather-plus">
           <line x1="12" y1="5" x2="12" y2="19"></line>
           <line x1="5" y1="12" x2="19" y2="12"></line>
-        </svg></button> <button class="stepper-input__icon--minus"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="custom-class feather feather-minus">
+        </svg></button> <button tabindex="-1" class="stepper-input__icon--minus"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="custom-class feather feather-minus">
           <line x1="5" y1="12" x2="19" y2="12"></line>
         </svg></button></div>
   </div>


### PR DESCRIPTION
- Impede que os botões de soma e subtração do input sejam selecionados com tab. O intuito é que quando vários stepper-inputs estiverem presentes o tab vai fazer com que o usuário navegue por eles rapidamente.