### PR TITLE
fix: Altera gerenciamento de atributos passados para o vcalendar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sysvale/cuida",
-  "version": "2.29.2",
+  "version": "2.29.3",
   "description": "A design system built by Sysvale, using storybook and Vue components",
   "repository": {
     "type": "git",

--- a/src/components/Calendar.vue
+++ b/src/components/Calendar.vue
@@ -212,6 +212,18 @@ export default {
 				this.showInLowResolution = newValue;
 			}
 		},
+
+		$attrs(newValue, oldValue) {
+			if (newValue !== oldValue) {
+				return;
+			}
+
+			this.resolveCalendarAttributes();
+		},
+	},
+
+	created() {
+		this.resolveCalendarAttributes();
 	},
 
 	methods: {
@@ -265,6 +277,13 @@ export default {
 				*/
 				this.$emit('scheduleSelected', this.selectedSchedule);
 			}
+		},
+
+		resolveCalendarAttributes() {
+			this.attributes = [
+				...this.attributes,
+				...this.$attrs.attributes,
+			];
 		},
 	},
 };


### PR DESCRIPTION
> :warning: **Estamos removendo o bootstrap como dependência de projeto**! Evite construir em cima de componentes do BootstrapVue e, se possível, evite utilizar classes do Bootstrap!

### Checklist do pull request

#### Por favor, verifique se o seu pull request está de acordo com o checklist abaixo:

-   [x] A implementação feita possui testes (Caso haja um motivo para não haver testes, descrever abaixo)
-   [x] A documentação no mdx foi feita ou atualizada, caso necessário
-   [x] O eslint passou localmente

### Tipo de pull request

-   [x] Fix
-   [ ] Feature
-   [ ] Melhoria no estilo de código (refatoração **sem** modificação na api)
-   [ ] Melhoria na escrita de métodos ou componentes (refatoração **com** modificação na api)
-   [ ] Modificação no build
-   [ ] Documentação

### Esse PR fecha alguma issue? Favor referenciá-la

### Quais são os passos para avaliar o pull request?

-   1 - Acesse o storybook do Cuida > Forms > Calendar
-   2 - Veja que o calendário continua sendo exibido corretamente
-   3 - No arquivo MDX correspondente, passe a prop `attributes` para o componente, de acordo com a [documentação do VCalendar](https://vcalendar.io/attributes.html) e verifique que os mesmos são utilizados pelo calendário
-   4 - Execute os testes
-   5 - Deixe seu like e se inscreva no canal

### Imagem ou exemplo de uso:

### Esse pull request adiciona _breaking changes_?

-   [ ] Sim
-   [x] Não

### Informações adicionais:
