### PR TITLE
fix: desabilita ícone de fechar de acordo com prop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@sysvale/cuida",
-  "version": "2.66.5",
+  "version": "2.66.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sysvale/cuida",
-  "version": "2.66.5",
+  "version": "2.66.6",
   "description": "A design system built by Sysvale, using storybook and Vue components",
   "repository": {
     "type": "git",

--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -20,13 +20,14 @@
 						<div
 							v-if="!noCloseButton"
 							class="cds-modal__close-icon"
+							:class="disabled ? 'cds-modal__close-icon--disabled' : ''"
 							@click="closeHandle"
 						>
 							<cds-icon
 								name="x-outline"
 								height="20"
 								width="20"
-								color="#29333D"
+								:color="disabled ? '#BCC7D2' : '#29333D'"
 							/>
 						</div>
 					</div>
@@ -185,6 +186,9 @@ export default {
 
 	methods: {
 		closeHandle() {
+			if (this.disabled) {
+				return;
+			}
 			/**
 			 * Evento que indica se o modal foi escondido.
 			* @event close
@@ -250,11 +254,16 @@ export default {
 	&__close-icon {
 		display: flex;
 		cursor: pointer;
+
+		&--disabled {
+			cursor: default;
+			color: $n-30;
+		}
 	}
 
 	&__body {
 		padding-right: 4.4px;
-		padding-left: 0.4px;
+		padding-left: 0.8px;
 	}
 
 	&__footer {


### PR DESCRIPTION
> :warning: **Estamos removendo o bootstrap como dependência de projeto**! Evite construir em cima de componentes do BootstrapVue e, se possível, evite utilizar classes do Bootstrap!

### Checklist do pull request

#### Por favor, verifique se o seu pull request está de acordo com o checklist abaixo:

-   [x] A implementação feita possui testes (Caso haja um motivo para não haver testes, descrever abaixo)
-   [x] A documentação no mdx foi feita ou atualizada, caso necessário
-   [x] O eslint passou localmente

### Tipo de pull request

-   [x] Fix
-   [ ] Feature
-   [ ] Melhoria no estilo de código (refatoração **sem** modificação na api)
-   [ ] Melhoria na escrita de métodos ou componentes (refatoração **com** modificação na api)
-   [ ] Modificação no build
-   [ ] Documentação

### Esse PR fecha alguma issue? Favor referenciá-la

<!-- Utilize o formato Closes: #numero da issue (Ex.: Closes #319) -->

### Quais são os passos para avaliar o pull request?

-   1 - Verifique o botão de fechar (ícone de X) fica desabilitado e não faz a ação quando `disabled` está setado;

### Imagem ou exemplo de uso:

### Esse pull request adiciona _breaking changes_?

-   [ ] Sim
-   [x] Não

### Informações adicionais:
