### PR TITLE
Feature/sidebar collapse state local storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sysvale/cuida",
-	"version": "3.74.2",
+	"version": "3.75.0",
 	"description": "A design system built by Sysvale, using storybook and Vue components",
 	"repository": {
 		"type": "git",

--- a/src/components/SideBar.vue
+++ b/src/components/SideBar.vue
@@ -410,7 +410,7 @@ export default {
 		*/
 		collapsibleState: {
 			type: Boolean,
-			default: false,
+			default: null,
 		},
 		/**
 		 * Imagem do logo que será renderizada
@@ -525,7 +525,6 @@ export default {
 
 	created() {
 		this.internalActiveItem = this.activeItem;
-		this.collapsed = this.collapsibleState;
 
 		this.items.forEach((item, idx) => {
 			this.itemsWithVisibilityController.push({
@@ -534,6 +533,17 @@ export default {
 				show: false,
 			})
 		});
+
+		if (!this.collapsible) {
+			return;
+		}
+
+		if (this.collapsibleState !== null) {
+			this.collapsed = this.collapsibleState;
+			return;
+		}
+
+		this.collapsed = window.localStorage.getItem('cdsSidebarCollapsed') ?? false;
 	},
 
 	methods: {
@@ -592,6 +602,7 @@ export default {
 		handleCollapse() {
 			this.$emit('collapse-click', !this.collapsed);
 			this.collapsed = !this.collapsed;
+			window.localStorage.setItem('cdsSidebarCollapsed', this.collapsed);	
 		},
 
 		resolveItemCollapse(item) {


### PR DESCRIPTION
#### Por favor, verifique se o seu pull request está de acordo com o checklist abaixo:

- [x] A implementação feita possui testes (Caso haja um motivo para não haver testes, descrever abaixo)
- [x] A documentação no mdx foi feita ou atualizada, caso necessário
- [x] O eslint passou localmente

### 1 - Resumo
Passa a salvar o estado do collapse da SideBar no localStorage do navegador.

### 2 - Tipo de pull request

- [ ] 🧱 Novo componente
- [x] ✨ Nova feature ou melhoria
- [ ] 🐛 Fix
- [ ] 👨‍💻 Refatoração
- [ ] 📝 Documentação
- [ ] 🎨 Estilo
- [ ] 🤖 Build ou CI/CD


### 3 - Esse PR fecha alguma issue? Favor referenciá-la

### 4 - Quais são os passos para avaliar o pull request?
- Rode o storybook;
- Acesse o arquivo MDX da SideBar e remova, na linha 224, o envio da prop `collapsibleState`;
- Acesse o storybook e vá em Componentes > Navegação > SideBar;
- Altere o estado do collapse do componente e atualize a página;
- Verifique que a barra vai estar colapsada, ou não, baseado na sua interação anterior;
- Verifique também que, caso a prop `collapsible` estiver falsa, a configuração não deve ser aplicada ao atualizar a página;
- Reverta a mudança no MDX e verifique que a prop `collapsibleState` é aplicada como prioridade.

### 5 - Imagem ou exemplo de uso:

### 6 - Esse pull request adiciona _breaking changes_?
- [ ] Sim
- [x] Não
