### PR TITLE
Feature/modal no close cancel

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sysvale/cuida",
-	"version": "3.77.0",
+	"version": "3.78.0",
 	"description": "A design system built by Sysvale, using storybook and Vue components",
 	"repository": {
 		"type": "git",

--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -60,7 +60,7 @@
 						:text="cancelButtonText"
 						secondary
 						:disabled="disableCancelButton"
-						@click="!disableCancelButton ? closeHandle() : false"
+						@click="!disableCancelButton ? cancelHandle() : false"
 					/>
 
 					<cds-button
@@ -156,6 +156,13 @@ export default {
 			default: false,
 		},
 		/**
+		 *  Controla a ação de fechar o modal ao clicar no botão de cancelar.
+		 */
+		noCloseCancelButton: {
+			type: Boolean,
+			default: false,
+		},
+		/**
 		 *  Controla a exibição do botão de fechar do modal.
 		 */
 		noCloseButton: {
@@ -218,7 +225,7 @@ export default {
 		return {
 			innerValue: false,
 			tmp: '',
-		}
+		};
 	},
 
 	computed: {
@@ -262,6 +269,20 @@ export default {
 				this.$emit('update:modelValue', false);
 			}
 			this.$emit('ok', true);
+		},
+
+		cancelHandle() {
+			/**
+			 * Evento que indica se o botão de cancelamento do modal foi clicado.
+			 * @event cancel
+			 * @type {Event}
+			*/
+			if (!this.noCloseCancelButton) {
+				this.innerValue = !this.innerValue;
+				this.$emit('close', true);
+				this.$emit('update:modelValue', false);
+			}
+			this.$emit('cancel');
 		},
 	},
 };

--- a/src/stories/components/Modal.stories.mdx
+++ b/src/stories/components/Modal.stories.mdx
@@ -80,6 +80,9 @@ export const Template = (args) => ({
 			<cds-modal
 				v-bind="args"
 				v-model="showModal"
+				@ok="console.info('evento ok emitido!')"
+				@cancel="console.info('evento cancelar emitido!')"
+				@close="console.info('evento de fechamento de modal emitido!')"
 			>
 				<span>
 					Mussum Ipsum, cacilds vidis litro abertis. A ordem dos tratores não altera o pão duris.Tá deprimidis,


### PR DESCRIPTION
#### Por favor, verifique se o seu pull request está de acordo com o checklist abaixo:

- [x] A implementação feita possui testes (Caso haja um motivo para não haver testes, descrever abaixo)
- [x] A documentação no mdx foi feita ou atualizada, caso necessário
- [x] O eslint passou localmente

### 1 - Resumo
Adiciona evento de clique no botão "Cancelar" do modal, separado do evento de fechamento de modal.

### 2 - Tipo de pull request

- [ ] 🧱 Novo componente
- [x] ✨ Nova feature ou melhoria
- [ ] 🐛 Fix
- [ ] 👨‍💻 Refatoração
- [ ] 📝 Documentação
- [ ] 🎨 Estilo
- [ ] 🤖 Build ou CI/CD


### 3 - Esse PR fecha alguma issue? Favor referenciá-la

### 4 - Quais são os passos para avaliar o pull request?
- Acesse o componente Modal;
- Verifique que agora existe uma nova prop chamada `noCloseCancelButton`, que controla se o modal deve ser fechado automaticamente no clique do botão "Cancelar", do footer;
- Ative-a e verifique se tudo está funcionando normalmente;
- Verifique também que os eventos são emitidos corretamente, através dos logs no inspetor;
- Desative a prop e verifique que o componente continua funcionando como sempre funcionou.

### 5 - Imagem ou exemplo de uso:

### 6 - Esse pull request adiciona _breaking changes_?
- [ ] Sim
- [x] Não
