### PR TITLE
Adiciona skeleton de carregamento ao componente tile

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sysvale/cuida",
-	"version": "3.94.0",
+	"version": "3.95.0",
 	"description": "A design system built by Sysvale, using storybook and Vue components",
 	"repository": {
 		"type": "git",

--- a/src/components/Tile.vue
+++ b/src/components/Tile.vue
@@ -137,7 +137,7 @@ const computedIconWidth = computed(() => {
 })
 
 function handleClick() {
-	if (props.disabled) {
+	if (props.disabled || props.loading) {
 		return;
 	}
 

--- a/src/components/Tile.vue
+++ b/src/components/Tile.vue
@@ -7,44 +7,39 @@
 		light
 		@box-click="handleClick"
 	>
-		<div class="cds-tile__extra-container">
+		<div
+			v-if="!loading"
+			class="cds-tile__extra-container"
+		>
 			<div class="cds-tile__extra">
 				<!-- @slot Slot para incluir conteúdo adicional no canto superior direito da tile.-->
 				<slot name="extra" />
 			</div>
 		</div>
-		<div :class="computedImageClass">
-			<skeleton
-				v-if="loading"
-				:width="computedIconWidth"
-				:height="computedIconWidth"
-			/>
-			<icon
-				v-else-if="computedIconType === 'icon'"
-				class="cds-tile__icon"
-				:name="icon"
-			/>
-			<cds-image
-				v-else
-				:src="icon"
-				:width="computedIconWidth"
-				rounded-corners
-				opacity="0.5"
-			/>
-		</div>
 		<div
 			v-if="loading"
-			class="cds-tile__text--loading"
+			:class="computedLoaderClass"
 		>
-			<skeleton-text
-				:width="computedIconWidth"
-			/>
+			<skeleton fluid	/>
 		</div>
-		<div
-			v-else
-			:class="computedTextClass"
-		>
-			{{ title }}
+		<div v-else>
+			<div :class="computedImageClass">
+				<icon
+					v-if="computedIconType === 'icon'"
+					class="cds-tile__icon"
+					:name="icon"
+				/>
+				<cds-image
+					v-else
+					:src="icon"
+					:width="computedIconWidth"
+					rounded-corners
+					opacity="0.5"
+				/>
+			</div>
+			<div :class="computedTextClass">
+				{{ title }}
+			</div>
 		</div>
 	</box>
 </template>
@@ -56,7 +51,6 @@ import Box from './Box.vue';
 import Icon from './Icon.vue';
 import CdsImage from './Image.vue';
 import Skeleton from './Skeleton.vue';
-import SkeletonText from './SkeletonText.vue';
 
 const props = defineProps({
 	/**
@@ -122,6 +116,8 @@ const computedVariant = computed(() => {
 
 	return props.variant;
 });
+
+const computedLoaderClass = computed(() => `cds-tile__loader--${props.size}`);
 const computedImageClass = computed(() => `cds-tile__image--${computedVariant.value} cds-tile__image--${props.size}`);
 const computedTextClass = computed(() => `cds-tile__text--${computedVariant.value} cds-tile__text--${props.size}`);
 const computedIconType = computed(() => (props.icon.includes('http') ? 'img' : 'icon'));
@@ -216,13 +212,6 @@ function handleClick() {
 			color: $n-300;
 		}
 
-		&--loading {
-			display: flex;
-			align-items: center;
-			justify-content: center;
-			padding: pa(2);
-		}
-
 		&--sm {
 			@include overline;
 			padding: pYX(2,4);
@@ -248,6 +237,23 @@ function handleClick() {
 		position: absolute;
 		right: spacer(2);
 		z-index: 9999;
+	}
+
+	&__loader {
+		&--sm {
+			width: 96px;
+			height: 102px;
+		}
+
+		&--md {
+			width: 106px;
+			height: 114px;
+		}
+
+		&--lg {
+			width: 116px;
+			height: 126px;
+		}
 	}
 }
 </style>

--- a/src/components/Tile.vue
+++ b/src/components/Tile.vue
@@ -14,8 +14,13 @@
 			</div>
 		</div>
 		<div :class="computedImageClass">
+			<skeleton
+				v-if="loading"
+				:width="computedIconWidth"
+				:height="computedIconWidth"
+			/>
 			<icon
-				v-if="computedIconType === 'icon'"
+				v-else-if="computedIconType === 'icon'"
 				class="cds-tile__icon"
 				:name="icon"
 			/>
@@ -27,7 +32,18 @@
 				opacity="0.5"
 			/>
 		</div>
-		<div :class="computedTextClass">
+		<div
+			v-if="loading"
+			class="cds-tile__text--loading"
+		>
+			<skeleton-text
+				:width="computedIconWidth"
+			/>
+		</div>
+		<div
+			v-else
+			:class="computedTextClass"
+		>
 			{{ title }}
 		</div>
 	</box>
@@ -39,6 +55,8 @@ import variantValidator from '../utils/validators/variant';
 import Box from './Box.vue';
 import Icon from './Icon.vue';
 import CdsImage from './Image.vue';
+import Skeleton from './Skeleton.vue';
+import SkeletonText from './SkeletonText.vue';
 
 const props = defineProps({
 	/**
@@ -46,14 +64,14 @@ const props = defineProps({
 	 */
 	icon: {
 		type: String,
-		required: true,
+		default: 'settings-outline',
 	},
 	/**
 	 * Texto a ser exibido no componente.
 	 */
 	title: {
 		type: String,
-		required: true,
+		default: '',
 	},
 	/**
 	 * Especifica o tamanho do botão. São 3 tamanhos implementados: 'sm', 'md', 'lg'.
@@ -76,6 +94,13 @@ const props = defineProps({
 	 * Controla o estado de desabilitação do componente.
 	*/
 	disabled: {
+		type: Boolean,
+		default: false,
+	},
+	/**
+	 * Controla o estado de carregamento do componente.
+	*/
+	loading: {
 		type: Boolean,
 		default: false,
 	},
@@ -191,9 +216,16 @@ function handleClick() {
 			color: $n-300;
 		}
 
+		&--loading {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			padding: pa(2);
+		}
+
 		&--sm {
-			padding: pYX(2,4);
 			@include overline;
+			padding: pYX(2,4);
 		}
 
 		&--md {
@@ -201,8 +233,8 @@ function handleClick() {
 		}
 
 		&--lg {
-			padding: pYX(2,7);
 			@include body-2;
+			padding: pYX(2,7);
 			font-weight: $font-weight-semibold;
 		}
 	}

--- a/src/components/Tile.vue
+++ b/src/components/Tile.vue
@@ -1,7 +1,7 @@
 <!-- eslint-disable vue/multi-word-component-names -->
 <template>
 	<box
-		:variant="computedVariant"
+		:variant="computedBoxVariant"
 		:clickable="!disabled"
 		padding="0"
 		light
@@ -117,6 +117,7 @@ const computedVariant = computed(() => {
 	return props.variant;
 });
 
+const computedBoxVariant = computed(() => (props.loading ? 'gray' : computedVariant.value));
 const computedLoaderClass = computed(() => `cds-tile__loader--${props.size}`);
 const computedImageClass = computed(() => `cds-tile__image--${computedVariant.value} cds-tile__image--${props.size}`);
 const computedTextClass = computed(() => `cds-tile__text--${computedVariant.value} cds-tile__text--${props.size}`);

--- a/src/stories/components/Tile.stories.mdx
+++ b/src/stories/components/Tile.stories.mdx
@@ -116,6 +116,7 @@ export const Template = (args) => ({
 			icon: 'trash-outline',
 			variant: 'green',
 			disabled: false,
+			loading: false,
 			title: 'Excluir',
 		}}
 	>

--- a/src/stories/components/Tile.stories.mdx
+++ b/src/stories/components/Tile.stories.mdx
@@ -80,7 +80,7 @@ export const Template = (args) => ({
 		</cds-tile>`,
 	methods: {
 		logTileClick(event) {
-			console.info('%con click: ', 'color: #2C70CD;', event);
+			console.info('%cFoi clicado ', 'color: #2C70CD;');
 		},
 	},
 });

--- a/src/tests/Tile.spec.ts
+++ b/src/tests/Tile.spec.ts
@@ -3,6 +3,8 @@ import { describe, test, expect } from 'vitest';
 import Tile from '../components/Tile.vue';
 import Icon from '../components/Icon.vue';
 import Image from '../components/Image.vue';
+import Skeleton from '../components/Skeleton.vue';
+import SkeletonText from '../components/SkeletonText.vue';
 import { mount, flushPromises } from '@vue/test-utils';
 
 describe('Tile', () => {
@@ -26,5 +28,27 @@ describe('Tile', () => {
 
 		expect(wrapper.findComponent(Icon).exists()).toBeFalsy();
 		expect(wrapper.findComponent(Image).exists()).toBeTruthy();
+	});
+
+	test('skeleton loads correctly', async () => {
+		const wrapper = mount(Tile, {
+			props: {
+				loading: true,
+			}
+		});
+
+		expect(wrapper.findComponent(Skeleton).exists()).toBeTruthy();
+		expect(wrapper.findComponent(SkeletonText).exists()).toBeTruthy();
+
+		wrapper.setProps({
+			title: 'Tile content',
+			icon: 'trash-outline',
+			loading: false,
+		});
+
+		await flushPromises();
+
+		expect(wrapper.findComponent(Skeleton).exists()).toBeFalsy();
+		expect(wrapper.findComponent(SkeletonText).exists()).toBeFalsy();
 	});
 });

--- a/src/tests/Tile.spec.ts
+++ b/src/tests/Tile.spec.ts
@@ -4,7 +4,6 @@ import Tile from '../components/Tile.vue';
 import Icon from '../components/Icon.vue';
 import Image from '../components/Image.vue';
 import Skeleton from '../components/Skeleton.vue';
-import SkeletonText from '../components/SkeletonText.vue';
 import { mount, flushPromises } from '@vue/test-utils';
 
 describe('Tile', () => {
@@ -38,7 +37,6 @@ describe('Tile', () => {
 		});
 
 		expect(wrapper.findComponent(Skeleton).exists()).toBeTruthy();
-		expect(wrapper.findComponent(SkeletonText).exists()).toBeTruthy();
 
 		wrapper.setProps({
 			title: 'Tile content',
@@ -49,6 +47,5 @@ describe('Tile', () => {
 		await flushPromises();
 
 		expect(wrapper.findComponent(Skeleton).exists()).toBeFalsy();
-		expect(wrapper.findComponent(SkeletonText).exists()).toBeFalsy();
 	});
 });

--- a/src/tests/__snapshots__/Tile.spec.ts.snap
+++ b/src/tests/__snapshots__/Tile.spec.ts.snap
@@ -15,10 +15,12 @@ exports[`Tile > renders correctly 1`] = `
           <!-- @slot Slot para incluir conteúdo adicional no canto superior direito da tile.-->
         </div>
       </div>
-      <div class="cds-tile__image--green cds-tile__image--md"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" aria-labelledby="trash-outline" role="presentation" class="cds-tile__icon">
-          <g fill="currentColor"></g>
-        </svg></div>
-      <div class="cds-tile__text--green cds-tile__text--md">Tile content</div>
+      <div>
+        <div class="cds-tile__image--green cds-tile__image--md"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" aria-labelledby="trash-outline" role="presentation" class="cds-tile__icon">
+            <g fill="currentColor"></g>
+          </svg></div>
+        <div class="cds-tile__text--green cds-tile__text--md">Tile content</div>
+      </div>
     </div>
   </div>
 </div>"


### PR DESCRIPTION
#### Por favor, verifique se o seu pull request está de acordo com o checklist abaixo:

- [x] A implementação feita possui testes (Caso haja um motivo para não haver testes/haver apenas testes de snapshot, descrever abaixo)
- [x] A documentação no mdx foi feita ou atualizada, caso necessário
- [x] O eslint passou localmente

### 1 - Resumo
- Adiciona estado de carregamento do componente Tile.

### 2 - Tipo de pull request

- [ ] 🧱 Novo componente
- [x] ✨ Nova feature ou melhoria
- [ ] 🐛 Fix
- [ ] 👨‍💻 Refatoração
- [ ] 📝 Documentação
- [ ] 🎨 Estilo
- [ ] 🤖 Build ou CI/CD


### 3 - Esse PR fecha alguma issue? Favor referenciá-la

### 4 - Quais são os passos para avaliar o pull request?
- Acesse o storybook > Componentes > Form > Tile;
- Verifique que agora o componente tem uma nova prop `loading`;
- Ative-a e verifique que o componente tem seu estado alterado para exibir skeletons de carregamento;
- Verifique também que o evento de clique não é emitido enquanto a prop está ativada;
- Deixe seu like e se inscreva no canal.

### 5 - Imagem ou exemplo de uso:
![image](https://github.com/user-attachments/assets/e6d0e2cb-9651-4222-8a1c-8b213d87f450)


### 6 - Esse pull request adiciona _breaking changes_?
- [ ] Sim
- [ ] Não
