### PR TITLE
feat: Adiciona prop state para gerenciar os estados do componente datatable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sysvale/cuida",
-	"version": "3.120.0",
+	"version": "3.121.0",
 	"description": "A design system built by Sysvale, using storybook and Vue components",
 	"repository": {
 		"type": "git",

--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -60,22 +60,23 @@
 				</div>
 				<div
 					v-else-if="isEmpty($attrs.items)"
-					class="empty"
 				>
-					<slot
-						v-if="hasStateEmpty"
-						name="empty"
-					/>
 					<div
-						v-else
+						v-if="hasStateEmpty"
 						class="empty"
 					>
-						<CdsImage
-							:src="emptyImgResolver"
-							width="200"
-						/>
-						<span class="empty__title">{{ emptyTitle }}</span>
-						<span class="empty__description">{{ emptyDescription }}</span>
+						<slot name="empty" />
+					</div>
+					<div v-else>
+						<CdsEmptyState
+							:image="emptyImgResolver"
+							:title="emptyTitle"
+							hide-action-button
+						>
+							<template #text>
+								{{ emptyDescription }}
+							</template>
+						</CdsEmptyState>
 					</div>
 				</div>
 				<cds-table
@@ -130,7 +131,7 @@ import CustomFieldsSideSheet from './InternalComponents/CustomFieldsSideSheet.vu
 import CdsFlexbox from './Flexbox.vue';
 import CdsSearchInput from './SearchInput.vue';
 import CdsSkeleton from './Skeleton.vue';
-import CdsImage from './Image.vue';
+import CdsEmptyState from './EmptyState.vue'
 
 const hasHeaderSlot = useHasSlot('header-item');
 const hasStateEmpty = useHasSlot('empty');
@@ -311,18 +312,6 @@ function handleSearchInput(value) {
 	flex-direction: column;
 	justify-content: center;
 	align-items: center;
-	color: tokens.$n-500;
-
-	&__title {
-		@include tokens.subheading-2;
-		font-weight: tokens.$font-weight-bold;
-		margin: tokens.mt(6);
-	}
-
-	&__description {
-		@include tokens.body-1;
-		margin: tokens.mt(1);
-	}
 }
 
 </style>

--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -195,7 +195,14 @@ const props = defineProps({
 		default: false,
 	},
 	/**
-	* Especifica o estado do input. As opções são 'default', 'empty', 'loading'.
+	 *  * Ativa o estado de carregamento do componente, desabilitando as ações superiores e exibindo um Skeleton para a tabela.
+	 */
+	loading: {
+		type: Boolean,
+		default: false,
+	},
+	/**
+	* Especifica o estado do input. As opções são 'default', 'empty'.
 	*/
 	state: {
 		type: String,
@@ -239,7 +246,6 @@ const computedMaxVisibleFields = computed(() => {
 	return props.maxVisibleFields > props.minVisibleFields ? props.maxVisibleFields : props.minVisibleFields;
 });
 
-const loading = computed(() => props.state === 'loading');
 const empty = computed(() => props.state === 'empty');
 
 const emptyImgResolver = computed(() => props.emptySrcImg ?? 'https://cdn-icons-png.flaticon.com/512/7486/7486747.png');

--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -58,6 +58,26 @@
 						</template>
 					</cds-table>
 				</div>
+				<div
+					v-else-if="empty"
+					class="empty"
+				>
+					<slot
+						v-if="hasStateEmpty"
+						name="empty"
+					/>
+					<div
+						v-else
+						class="empty"
+					>
+						<CdsImage
+							:src="emptySrcImg"
+							width="200"
+						/>
+						<span class="empty__title">{{ emptyTitle }}</span>
+						<span class="empty__description">{{ emptyDescription }}</span>
+					</div>
+				</div>
 				<cds-table
 					v-else
 					v-bind="$attrs"
@@ -110,8 +130,10 @@ import CustomFieldsSideSheet from './InternalComponents/CustomFieldsSideSheet.vu
 import CdsFlexbox from './Flexbox.vue';
 import CdsSearchInput from './SearchInput.vue';
 import CdsSkeleton from './Skeleton.vue';
+import CdsImage from './Image.vue';
 
 const hasHeaderSlot = useHasSlot('header-item');
+const hasStateEmpty = useHasSlot('empty');
 
 const props = defineProps({
 	/**
@@ -166,18 +188,39 @@ const props = defineProps({
 		validator: (value) => value >= 0,
 	},
 	/**
- 	* Especifica se a barra de busca da tabela deve ser exibida.
+	* Especifica se a barra de busca da tabela deve ser exibida.
 	*/
 	withSearch: {
 		type: Boolean,
 		default: false,
 	},
 	/**
-	 * Ativa o estado de carregamento do componente, desabilitando as ações superiores e exibindo um Skeleton para a tabela.
+	* Especifica o estado do input. As opções são 'default', 'empty', 'loading'.
+	*/
+	state: {
+		type: String,
+		default: 'default',
+	},
+	/**
+	* Caminho da imagem que vai ser renderizada quando o estado for empty.
+	*/
+	emptySrcImg: {
+		type: String,
+		default: '',
+	},
+	/**
+	 * Título que vai ser renderizado quando o estado for empty.
 	 */
-	loading: {
-		type: Boolean,
-		default: false,
+	emptyTitle: {
+		type: String,
+		default: '',
+	},
+	/**
+	 * Descrição que vai ser renderizado quando o estado for empty.
+	 */
+	emptyDescription: {
+		type: String,
+		default: '',
 	},
 });
 
@@ -195,6 +238,9 @@ const computedMaxVisibleFields = computed(() => {
 
 	return props.maxVisibleFields > props.minVisibleFields ? props.maxVisibleFields : props.minVisibleFields;
 });
+
+const loading = computed(() => props.state === 'loading');
+const empty = computed(() => props.state === 'empty');
 
 watch(() => props.customFieldsList, () => {
 	internalCustomFieldsList.value = cloneDeep(props.customFieldsList);
@@ -257,6 +303,26 @@ function handleSearchInput(value) {
 
 	&__table-container {
 		overflow-x: auto;
+	}
+}
+
+.empty {
+	margin: tokens.mt(4);
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+	color: tokens.$n-500;
+
+	&__title {
+		@include tokens.subheading-2;
+		font-weight: tokens.$font-weight-bold;
+		margin: tokens.mt(6);
+	}
+
+	&__description {
+		@include tokens.body-1;
+		margin: tokens.mt(1);
 	}
 }
 

--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -59,7 +59,7 @@
 					</cds-table>
 				</div>
 				<div
-					v-else-if="empty"
+					v-else-if="isEmpty"
 					class="empty"
 				>
 					<slot
@@ -202,11 +202,11 @@ const props = defineProps({
 		default: false,
 	},
 	/**
-	* Especifica o estado do input. As opções são 'default', 'empty'.
+	* Ativa o estado vazio do componente. Utilizar quando desejar gerenciar retornos vazios de filtragens.
 	*/
-	state: {
-		type: String,
-		default: 'default',
+	isEmpty: {
+		type: Boolean,
+		default: false,
 	},
 	/**
 	* Caminho da imagem que vai ser renderizada quando o estado for empty.
@@ -245,8 +245,6 @@ const computedMaxVisibleFields = computed(() => {
 
 	return props.maxVisibleFields > props.minVisibleFields ? props.maxVisibleFields : props.minVisibleFields;
 });
-
-const empty = computed(() => props.state === 'empty');
 
 const emptyImgResolver = computed(() => props.emptySrcImg ?? 'https://cdn-icons-png.flaticon.com/512/7486/7486747.png');
 

--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -59,7 +59,7 @@
 					</cds-table>
 				</div>
 				<div
-					v-else-if="isEmpty"
+					v-else-if="isEmpty($attrs.items)"
 					class="empty"
 				>
 					<slot
@@ -122,7 +122,7 @@
 
 <script setup>
 import { ref, watch, computed } from 'vue';
-import { cloneDeep } from 'lodash';
+import { cloneDeep, isEmpty } from 'lodash';
 import { useHasSlot } from '../utils/composables/useHasSlot';
 import CdsButton from './Button.vue';
 import CdsTable from './Table.vue';
@@ -198,13 +198,6 @@ const props = defineProps({
 	 *  * Ativa o estado de carregamento do componente, desabilitando as ações superiores e exibindo um Skeleton para a tabela.
 	 */
 	loading: {
-		type: Boolean,
-		default: false,
-	},
-	/**
-	* Ativa o estado vazio do componente. Utilizar quando desejar gerenciar retornos vazios de filtragens.
-	*/
-	isEmpty: {
 		type: Boolean,
 		default: false,
 	},

--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -71,7 +71,7 @@
 						class="empty"
 					>
 						<CdsImage
-							:src="emptySrcImg"
+							:src="emptyImgResolver"
 							width="200"
 						/>
 						<span class="empty__title">{{ emptyTitle }}</span>
@@ -206,21 +206,21 @@ const props = defineProps({
 	*/
 	emptySrcImg: {
 		type: String,
-		default: '',
+		default: null,
 	},
 	/**
 	 * Título que vai ser renderizado quando o estado for empty.
 	 */
 	emptyTitle: {
 		type: String,
-		default: '',
+		default: 'Nenhum registro',
 	},
 	/**
 	 * Descrição que vai ser renderizado quando o estado for empty.
 	 */
 	emptyDescription: {
 		type: String,
-		default: '',
+		default: 'Certifique-se de ajustar os filtros para encontrar resultados.',
 	},
 });
 
@@ -241,6 +241,8 @@ const computedMaxVisibleFields = computed(() => {
 
 const loading = computed(() => props.state === 'loading');
 const empty = computed(() => props.state === 'empty');
+
+const emptyImgResolver = computed(() => props.emptySrcImg ?? 'https://cdn-icons-png.flaticon.com/512/7486/7486747.png');
 
 watch(() => props.customFieldsList, () => {
 	internalCustomFieldsList.value = cloneDeep(props.customFieldsList);

--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -196,7 +196,7 @@ const props = defineProps({
 		default: false,
 	},
 	/**
-	 *  * Ativa o estado de carregamento do componente, desabilitando as ações superiores e exibindo um Skeleton para a tabela.
+	 * Ativa o estado de carregamento do componente, desabilitando as ações superiores e exibindo um Skeleton para a tabela.
 	 */
 	loading: {
 		type: Boolean,

--- a/src/stories/components/DataTable.stories.mdx
+++ b/src/stories/components/DataTable.stories.mdx
@@ -10,7 +10,6 @@ import DataTable from '../../components/DataTable.vue';
 				type: 'select',
 				options: [
 					'default',
-					'loading',
 					'empty',
 				],
 			}

--- a/src/stories/components/DataTable.stories.mdx
+++ b/src/stories/components/DataTable.stories.mdx
@@ -5,15 +5,6 @@ import DataTable from '../../components/DataTable.vue';
 	title="Componentes/Display/DataTable"
 	component={ DataTable }
 	argTypes={{
-		state: {
-			control:{
-				type: 'select',
-				options: [
-					'default',
-					'empty',
-				],
-			}
-		},
 		selectionVariant: {
 			control:{
 				type: 'select',
@@ -233,7 +224,6 @@ export const customFields = [
 			customFieldsList: customFields,
 			minVisibleFields: 1,
 			maxVisibleFields: 0,
-			state: 'default',
 		}}
 	>
 		{ Template.bind({}) }

--- a/src/stories/components/DataTable.stories.mdx
+++ b/src/stories/components/DataTable.stories.mdx
@@ -5,6 +5,16 @@ import DataTable from '../../components/DataTable.vue';
 	title="Componentes/Display/DataTable"
 	component={ DataTable }
 	argTypes={{
+		state: {
+			control:{
+				type: 'select',
+				options: [
+					'default',
+					'loading',
+					'empty',
+				],
+			}
+		},
 		selectionVariant: {
 			control:{
 				type: 'select',
@@ -224,6 +234,7 @@ export const customFields = [
 			customFieldsList: customFields,
 			minVisibleFields: 1,
 			maxVisibleFields: 0,
+			state: 'default',
 		}}
 	>
 		{ Template.bind({}) }


### PR DESCRIPTION
… e empty

#### Por favor, verifique se o seu pull request está de acordo com o checklist abaixo:

- [x] A implementação feita possui testes (Caso haja um motivo para não haver testes/haver apenas testes de snapshot, descrever abaixo)
- [x] A documentação no mdx foi feita ou atualizada, caso necessário
- [x] O eslint passou localmente

### 1 - Resumo
- Adiciona prop _state_ para permitir gerenciar estados internos do componente DataTable
- Os estados são: default, loading e empty

### 2 - Tipo de pull request

- [ ] 🧱 Novo componente
- [x] ✨ Nova feature ou melhoria
- [ ] 🐛 Fix
- [ ] 👨‍💻 Refatoração
- [ ] 📝 Documentação
- [ ] 🎨 Estilo
- [ ] 🤖 Build ou CI/CD


### 3 - Esse PR fecha alguma issue? Favor referenciá-la
Não

### 4 - Quais são os passos para avaliar o pull request?
- Verifique que quando o estado for default retorna a exibição padrão dos elementos do componente;
- Verifique que quando o estado estiver como loading, será exibido skeleton mostrando loading nos elementos internos da tabela;
- Verifique que quando o estado estiver como empty, existirá duas situações
     * 1 - Uso do slot _#empty_ que permitirá personalizar conteúdo interno
     * 2 - Quando quiser usar elementos já internos, aplicar as props: _emptySrcImg_, _emptyTitle_, _emptyDescription_

### 5 - Imagem ou exemplo de uso:
![image](https://github.com/user-attachments/assets/78e5f016-c879-4577-8c88-4454a6a6c8e1)


### 6 - Esse pull request adiciona _breaking changes_?
- [ ] Sim
- [X] Não
