### PR TITLE
Feature/table customize sidesheet presets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@sysvale/cuida",
-	"version": "3.124.5",
+	"version": "3.126.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@sysvale/cuida",
-			"version": "3.124.5",
+			"version": "3.126.0",
 			"dependencies": {
 				"@popperjs/core": "^2.11.6",
 				"@sysvale/cuida-icons": "^1.17.0",
@@ -39,7 +39,7 @@
 				"@storybook/vue3": "^6.5.10",
 				"@types/vue": "^2.0.0",
 				"@vitejs/plugin-vue": "^5.1.4",
-				"@vitest/coverage-v8": "^3.2.1",
+				"@vitest/coverage-v8": "^3.1.1",
 				"@vitest/ui": "^3.2.1",
 				"@vue/test-utils": "^2.0.2",
 				"babel-loader": "^8.2.5",
@@ -6206,23 +6206,21 @@
 			}
 		},
 		"node_modules/@vitest/coverage-v8": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.1.tgz",
-			"integrity": "sha512-6dy0uF/0BE3jpUW9bFzg0V2S4F7XVaZHL/7qma1XANvHPQGoJuc3wtx911zSoAgUnpfvcLVK1vancNJ95d+uxQ==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.1.1.tgz",
+			"integrity": "sha512-MgV6D2dhpD6Hp/uroUoAIvFqA8AuvXEFBC2eepG3WFc1pxTfdk1LEqqkWoWhjz+rytoqrnUUCdf6Lzco3iHkLQ==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@ampproject/remapping": "^2.3.0",
 				"@bcoe/v8-coverage": "^1.0.2",
-				"ast-v8-to-istanbul": "^0.3.3",
-				"debug": "^4.4.1",
+				"debug": "^4.4.0",
 				"istanbul-lib-coverage": "^3.2.2",
 				"istanbul-lib-report": "^3.0.1",
 				"istanbul-lib-source-maps": "^5.0.6",
 				"istanbul-reports": "^3.1.7",
 				"magic-string": "^0.30.17",
 				"magicast": "^0.3.5",
-				"std-env": "^3.9.0",
+				"std-env": "^3.8.1",
 				"test-exclude": "^7.0.1",
 				"tinyrainbow": "^2.0.0"
 			},
@@ -6230,8 +6228,8 @@
 				"url": "https://opencollective.com/vitest"
 			},
 			"peerDependencies": {
-				"@vitest/browser": "3.2.1",
-				"vitest": "3.2.1"
+				"@vitest/browser": "3.1.1",
+				"vitest": "3.1.1"
 			},
 			"peerDependenciesMeta": {
 				"@vitest/browser": {
@@ -7676,42 +7674,6 @@
 			"engines": {
 				"node": ">=4"
 			}
-		},
-		"node_modules/ast-v8-to-istanbul": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.3.tgz",
-			"integrity": "sha512-MuXMrSLVVoA6sYN/6Hke18vMzrT4TZNbZIj/hvh0fnYFpO+/kFXcLIaiPwXXWaQUPg4yJD8fj+lfJ7/1EBconw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jridgewell/trace-mapping": "^0.3.25",
-				"estree-walker": "^3.0.3",
-				"js-tokens": "^9.0.1"
-			}
-		},
-		"node_modules/ast-v8-to-istanbul/node_modules/@types/estree": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
-			"integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/ast-v8-to-istanbul/node_modules/estree-walker": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/estree": "^1.0.0"
-			}
-		},
-		"node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-			"integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/async-each": {
 			"version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sysvale/cuida",
-	"version": "3.126.0",
+	"version": "3.127.0",
 	"description": "A design system built by Sysvale, using storybook and Vue components",
 	"repository": {
 		"type": "git",
@@ -60,7 +60,7 @@
 		"@storybook/vue3": "^6.5.10",
 		"@types/vue": "^2.0.0",
 		"@vitejs/plugin-vue": "^5.1.4",
-		"@vitest/coverage-v8": "^3.2.1",
+		"@vitest/coverage-v8": "^3.1.1",
 		"@vitest/ui": "^3.2.1",
 		"@vue/test-utils": "^2.0.2",
 		"babel-loader": "^8.2.5",

--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -140,6 +140,7 @@
 			v-model="showSideSheet"
 			:custom-fields-list="internalCustomFieldsList"
 			:selection-variant="selectionVariant"
+			:presets-options="presetsOptions"
 			:loading-custom-fields="loadingCustomFields"
 			:min-fields="minVisibleFields"
 			:max-fields="computedMaxVisibleFields"
@@ -196,6 +197,13 @@ const props = defineProps({
 	hideCustomizeButton: {
 		type: Boolean,
 		default: false,
+	},
+	/**
+	* Define as opções de presets que serão exibidas no sidesheet de personalizar tabela. Se nenhum for fornecido, não será exibido.
+	*/
+	presetsOptions: {
+		type: Array,
+		default: () => [],
 	},
 	/**
 	* Ativa o feedback de loading no sidesheet de personalizar tabela.

--- a/src/components/InternalComponents/CustomFieldsSideSheet.vue
+++ b/src/components/InternalComponents/CustomFieldsSideSheet.vue
@@ -18,14 +18,16 @@
 					{{ descriptionComputedText }}
 				</div>
 
-				<CdsSelect
-					v-model="selectedPreset"
-					class="side-sheet__presets"
-					label="Conjunto padrão de colunas (preset)"
-					placeholder="Selecione um preset"
-					:options="resolvedPresetsOptions"
-					fluid
-				/>
+				<template v-if="presetsOptions.length > 0">
+					<CdsSelect
+						v-model="selectedPreset"
+						class="side-sheet__presets"
+						label="Conjunto padrão de colunas (preset)"
+						placeholder="Selecione um preset"
+						:options="resolvedPresetsOptions"
+						fluid
+					/>
+				</template>
 
 				<CdsFlexbox
 					v-if="loadingCustomFields"

--- a/src/components/InternalComponents/CustomFieldsSideSheet.vue
+++ b/src/components/InternalComponents/CustomFieldsSideSheet.vue
@@ -21,8 +21,8 @@
 				<CdsSelect
 					v-model="selectedPreset"
 					class="side-sheet__presets"
-					label=""
-					placeholder="Selecione um preset de colunas"
+					label="Conjunto padrão de colunas (preset)"
+					placeholder="Selecione um preset"
 					:options="resolvedPresetsOptions"
 					fluid
 				/>
@@ -256,13 +256,13 @@ function currentPreset() {
 .side-sheet {
 
 	&__presets {
-		margin: tokens.mb(3);
+		margin: tokens.mb(4);
 	}
 
 	&__description {
 		@include tokens.body-2;
 		color: tokens.$n-600;
-		margin: tokens.mb(4);
+		margin: tokens.mb(5);
 	}
 
 	&__item-label {

--- a/src/stories/components/DataTable.stories.mdx
+++ b/src/stories/components/DataTable.stories.mdx
@@ -127,42 +127,6 @@ export const fields = [
 		key: 'field_4',
 		label: 'Field 4',
 	},
-	{
-		key: 'field-5',
-		label: 'Field 5',
-	},
-	{
-		key: 'field_6',
-		label: 'Field 6',
-	},
-	{
-		key: 'field-7',
-		label: 'Field 7',
-	},
-	{
-		key: 'field_8',
-		label: 'Field 8',
-	},
-	{
-		key: 'field_9',
-		label: 'Field 9',
-	},
-	{
-		key: 'field-10',
-		label: 'Field 10',
-	},
-	{
-		key: 'field_11',
-		label: 'Field 11',
-	},
-	{
-		key: 'field-12',
-		label: 'Field 12',
-	},
-	{
-		key: 'field_13',
-		label: 'Field 13',
-	},
 ];
 
 export const items = [
@@ -253,33 +217,56 @@ export const items2 = [
 export const customFields = [
 	{
 		label: 'Nome',
-		id: '1',
+		id: 'nome',
 		visible: true,
 	},
 	{
 		label: 'Sobrenome',
-		id: '2',
-		visible: true,
+		id: 'sobrenome',
+		visible: false,
 	},
 	{
 		label: 'Idade',
-		id: '3',
+		id: 'idade',
 		visible: true,
 	},
 	{
 		label: 'CPF',
-		id: '4',
-		visible: false,
+		id: 'cpf',
+		visible: true,
 	},
 	{
 		label: 'RG',
-		id: '5',
+		id: 'rg',
 		visible: false,
 	},
 	{
 		label: 'Endereço',
-		id: '6',
-		visible: true,
+		id: 'endereco',
+		visible: false,
+	}
+];
+
+export const presetsOptions = [
+	{
+		label: 'Basicão',
+		columns: ['nome', 'sobrenome', 'idade']
+	},
+	{
+		label: 'Pessoal',
+		columns: ['nome', 'idade', 'cpf']
+	},
+	{
+		label: 'Endereço',
+		columns: ['nome', 'endereco']
+	},
+	{
+		label: 'Documentos',
+		columns: ['nome', 'sobrenome', 'cpf', 'rg']
+	},
+	{
+		label: 'X-Tudo',
+		columns: ['nome', 'sobrenome', 'idade', 'cpf', 'rg', 'endereco']
 	}
 ];
 
@@ -293,6 +280,7 @@ export const customFields = [
 			allowSelection: false,
 			selectionVariant: 'green',
 			totalItems: 100,
+			presetsOptions: presetsOptions,
 			customFieldsList: customFields,
 			minVisibleFields: 1,
 			maxVisibleFields: 0,

--- a/src/tests/__snapshots__/DataTable.spec.ts.snap
+++ b/src/tests/__snapshots__/DataTable.spec.ts.snap
@@ -18,6 +18,6 @@ exports[`DataTable > renders correctly 1`] = `
       <cds-table-stub data-v-046d4556="" modelvalue="" items="[object Object],[object Object]" fields="field1,field2,field3" hover="false" allowselection="false" selectionvariant="green" sortable="false" fixedheader="false" sortdesc="false" nowrap="false"></cds-table-stub>
     </div>
   </div>
-  <custom-fields-side-sheet-stub data-v-046d4556="" minfields="1" maxfields="Infinity" customfieldslist="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]" selectionvariant="green" loadingcustomfields="false" shoulddisableokbutton="false" modelvalue="false"></custom-fields-side-sheet-stub>
+  <custom-fields-side-sheet-stub data-v-046d4556="" minfields="1" maxfields="Infinity" customfieldslist="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]" selectionvariant="green" presetsoptions="" loadingcustomfields="false" shoulddisableokbutton="false" modelvalue="false"></custom-fields-side-sheet-stub>
 </div>"
 `;


### PR DESCRIPTION
#### Por favor, verifique se o seu pull request está de acordo com o checklist abaixo:

- [x] A implementação feita possui testes (Caso haja um motivo para não haver testes/haver apenas testes de snapshot, descrever abaixo)
- [x] A documentação no mdx foi feita ou atualizada, caso necessário
- [x] O eslint passou localmente

### 1 - Resumo
Adiciona uma nova prop ao Datatable, de presets de colunas.

### 2 - Tipo de pull request

- [ ] 🧱 Novo componente
- [x] ✨ Nova feature ou melhoria
- [ ] 🐛 Fix
- [ ] 👨‍💻 Refatoração
- [ ] 📝 Documentação
- [ ] 🎨 Estilo
- [ ] 🤖 Build ou CI/CD


### 3 - Esse PR fecha alguma issue? Favor referenciá-la
Não.

### 4 - Quais são os passos para avaliar o pull request?
- Acesse a página do Datatable na documentação.
- Verifique a prop presetOptions e perceba que ela manda uma lista de presets.
- Abra o sidesheet de personalização da tabela e brinque com os presets.
- Teste que os presets alteram as colunas ativas e que o inverso também acontece.
- Revise o código.
- Tente quebrar e requebrar.

### 5 - Imagem ou exemplo de uso:

### 6 - Esse pull request adiciona _breaking changes_?
- [ ] Sim
- [x] Não
