### PR TITLE
Bugfix/detect preset comparation function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sysvale/cuida",
-	"version": "3.129.0",
+	"version": "3.129.1",
 	"description": "A design system built by Sysvale, using storybook and Vue components",
 	"repository": {
 		"type": "git",

--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -163,7 +163,7 @@
 
 <script setup>
 import { ref, watch, computed, useAttrs, onMounted, onUnmounted, nextTick } from 'vue';
-import { cloneDeep, isEmpty, isEqual } from 'lodash';
+import { cloneDeep, isEmpty } from 'lodash';
 import { useHasSlot } from '../utils/composables/useHasSlot';
 import generateKey from '../utils/methods/uuidv4';
 import CdsButton from './Button.vue';
@@ -441,11 +441,20 @@ function handleUpdatePreset(presetName) {
 	selectedPresetName.value = presetName;
 }
 
+const hasSameItems = (arr1, arr2) => {
+	if (arr1.length !== arr2.length) return false;
+
+	const sorted1 = [...arr1].sort();
+	const sorted2 = [...arr2].sort();
+
+	return sorted1.every((item, index) => item === sorted2[index]);
+};
+
 function resolveInitialPreset() {
 	nextTick(() => {
 		const columnsKeys = attrs.fields.map((field) => field.key);
 		const foundPresetLabel = props.presetsOptions.find((preset) => {
-			return isEqual(preset.columns, columnsKeys);
+			return hasSameItems(preset.columns, columnsKeys);
 		});
 
 		if (foundPresetLabel) {

--- a/src/components/InternalComponents/CustomFieldsSideSheet.vue
+++ b/src/components/InternalComponents/CustomFieldsSideSheet.vue
@@ -130,7 +130,7 @@ import CdsFlexbox from '../Flexbox.vue';
 import CdsButton from '../Button.vue';
 import CdsSelect from '../Select.vue';
 import CdsSearchInput from '../SearchInput.vue';
-import { isEmpty, isEqual, kebabCase, trim } from 'lodash';
+import { isEmpty, kebabCase, trim } from 'lodash';
 
 const modelValue = defineModel({
 	type: Boolean,
@@ -310,6 +310,15 @@ function syncInternalCustomFieldsList() {
 	});
 }
 
+const hasSameItems = (arr1, arr2) => {
+	if (arr1.length !== arr2.length) return false;
+
+	const sorted1 = [...arr1].sort();
+	const sorted2 = [...arr2].sort();
+
+	return sorted1.every((item, index) => item === sorted2[index]);
+};
+
 function currentPreset() {
 	syncInternalCustomFieldsList();
 
@@ -317,7 +326,7 @@ function currentPreset() {
 		filter(({ visible }) => visible === true).
 		map(field => field[props.trackBy]);
 	const foundPreset = props.presetsOptions.find(({ columns }) => {
-		return isEqual(columns, currentSelectedColumns);
+		return hasSameItems(columns, currentSelectedColumns);
 	});
 
 	if (!foundPreset) {


### PR DESCRIPTION
#### Por favor, verifique se o seu pull request está de acordo com o checklist abaixo:

- [x] A implementação feita possui testes (Caso haja um motivo para não haver testes/haver apenas testes de snapshot, descrever abaixo)
- [x] A documentação no mdx foi feita ou atualizada, caso necessário
- [x] O eslint passou localmente

### 1 - Resumo
Implementa função para verificar se os itens entre dois arrays são os mesmos, deixando de usar o isEquals do LoDash que gerava bugs

### 2 - Tipo de pull request

- [ ] 🧱 Novo componente
- [ ] ✨ Nova feature ou melhoria
- [x] 🐛 Fix
- [ ] 👨‍💻 Refatoração
- [ ] 📝 Documentação
- [ ] 🎨 Estilo
- [ ] 🤖 Build ou CI/CD


### 3 - Esse PR fecha alguma issue? Favor referenciá-la

### 4 - Quais são os passos para avaliar o pull request?
- Verifique que agora, mesmo mandando as colunas em diferentes ordem em cada item do presetsOptions, a escolha de presets continua funcionando perfeitamente.

### 5 - Imagem ou exemplo de uso:

### 6 - Esse pull request adiciona _breaking changes_?
- [ ] Sim
- [ ] Não
