### PR TITLE
Bugfix/disable external scroll

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@sysvale/cuida",
-	"version": "3.128.0",
+	"version": "3.131.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@sysvale/cuida",
-			"version": "3.128.0",
+			"version": "3.131.1",
 			"dependencies": {
 				"@popperjs/core": "^2.11.6",
 				"@sysvale/cuida-icons": "^1.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sysvale/cuida",
-	"version": "3.131.0",
+	"version": "3.131.1",
 	"description": "A design system built by Sysvale, using storybook and Vue components",
 	"repository": {
 		"type": "git",

--- a/src/components/InternalComponents/CustomFieldsSideSheet.vue
+++ b/src/components/InternalComponents/CustomFieldsSideSheet.vue
@@ -126,7 +126,7 @@
 </template>
 
 <script setup>
-import { ref, watch, computed, onMounted } from 'vue';
+import { ref, watch, computed, onMounted, onBeforeUnmount } from 'vue';
 import hasSameItems from '../../utils/methods/hasSameItems';
 import CdsIcon from '../Icon.vue';
 import CdsSkeleton from '../Skeleton.vue';
@@ -286,6 +286,10 @@ watch(() => props.customFieldsList, (value) => {
 	filteredCustomFieldsList.value = [...value.map(field => ({ ...field }))];
 	currentPreset();
 }, { deep: true });
+
+onBeforeUnmount(() => {
+	document.body.style.overflow = 'auto';
+})
 
 onMounted(() => {
 	internalCustomFieldsList.value = [...props.customFieldsList.map(field => ({ ...field }))];


### PR DESCRIPTION
#### Por favor, verifique se o seu pull request está de acordo com o checklist abaixo:

- [x] A implementação feita possui testes (Caso haja um motivo para não haver testes/haver apenas testes de snapshot, descrever abaixo)
- [x] A documentação no mdx foi feita ou atualizada, caso necessário
- [x] O eslint passou localmente

### 1 - Resumo
- Ocorre problemas de manter overflow hidden quando SideSheet da tabela de personalização de itens da DataTables é fechada quando está utilizando a prop `loadingCustomFields` está sendo utilizada.

### 2 - Tipo de pull request

- [ ] 🧱 Novo componente
- [ ] ✨ Nova feature ou melhoria
- [X] 🐛 Fix
- [ ] 👨‍💻 Refatoração
- [ ] 📝 Documentação
- [ ] 🎨 Estilo
- [ ] 🤖 Build ou CI/CD


### 3 - Esse PR fecha alguma issue? Favor referenciá-la
Não

### 4 - Quais são os passos para avaliar o pull request?
- Execute o fluxo normal de abrir e fechar e verifique que o overflow não está sendo mantido

### 5 - Imagem ou exemplo de uso:

### 6 - Esse pull request adiciona _breaking changes_?
- [ ] Sim
- [X] Não
