### PR TITLE
fix/base-mobile-input-neutral-state

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sysvale/cuida",
-	"version": "3.137.5",
+	"version": "3.137.6",
 	"description": "A design system built by Sysvale, using storybook and Vue components",
 	"repository": {
 		"type": "git",

--- a/src/components/BaseInput.vue
+++ b/src/components/BaseInput.vue
@@ -3,7 +3,7 @@
 		<CdsBaseMobileInput
 			v-if="floatingLabel"
 			ref="mobileInput"
-			v-bind="props"
+			v-bind="{...$attrs, ...props}"
 			v-model="internalValue"
 			:has-leading-icon="hasLeadingIcon"
 			:has-trailing-icon="hasTrailingIcon"

--- a/src/tests/__snapshots__/DateInput.spec.js.snap
+++ b/src/tests/__snapshots__/DateInput.spec.js.snap
@@ -30,7 +30,7 @@ exports[`DateInput > renders correctly 1`] = `
     <div data-v-fcd39cd1="" class="date-input__calendar--down" style="display: none;">
       <div data-v-fcd39cd1="" class="calendar__header">
         <div data-v-c2ac4e6d="" data-v-fcd39cd1="" class="flexbox">
-          <!-- @slot Slot com o conteúdo interno do FlexBox --><span data-v-fcd39cd1="" class="calendar__month-and-title">agosto</span><span data-v-fcd39cd1="" class="calendar__month-and-title">2025</span>
+          <!-- @slot Slot com o conteúdo interno do FlexBox --><span data-v-fcd39cd1="" class="calendar__month-and-title">setembro</span><span data-v-fcd39cd1="" class="calendar__month-and-title">2025</span>
         </div>
         <div data-v-c2ac4e6d="" data-v-fcd39cd1="" class="flexbox">
           <!-- @slot Slot com o conteúdo interno do FlexBox --><svg data-v-fcd39cd1="" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" aria-labelledby="caret-up-outline" role="presentation" class="calendar__right-caret">
@@ -53,10 +53,6 @@ exports[`DateInput > renders correctly 1`] = `
         <div data-v-fcd39cd1="" class="calendar__week-day">S</div>
         <div data-v-fcd39cd1="" class="calendar__week-day">S</div>
         <div data-v-fcd39cd1="" class="calendar__week-day">D</div>
-        <div data-v-fcd39cd1="" class="calendar__empty-day"></div>
-        <div data-v-fcd39cd1="" class="calendar__empty-day"></div>
-        <div data-v-fcd39cd1="" class="calendar__empty-day"></div>
-        <div data-v-fcd39cd1="" class="calendar__empty-day"></div>
         <div data-v-fcd39cd1="" class="calendar__day--green" disabled="false">1</div>
         <div data-v-fcd39cd1="" class="calendar__day--green" disabled="false">2</div>
         <div data-v-fcd39cd1="" class="calendar__day--green" disabled="false">3</div>
@@ -87,7 +83,6 @@ exports[`DateInput > renders correctly 1`] = `
         <div data-v-fcd39cd1="" class="calendar__day--green" disabled="false">28</div>
         <div data-v-fcd39cd1="" class="calendar__day--green" disabled="false">29</div>
         <div data-v-fcd39cd1="" class="calendar__day--green" disabled="false">30</div>
-        <div data-v-fcd39cd1="" class="calendar__day--green" disabled="false">31</div>
       </div>
       <div data-v-958116c6="" data-v-44dffe1e="" data-v-fcd39cd1="" class="grid month-selector__grid" style="display: none;">
         <!-- @slot Slot com o conteúdo interno da grid -->


### PR DESCRIPTION
#### Por favor, verifique se o seu pull request está de acordo com o checklist abaixo:

- [x] A implementação feita possui testes (Caso haja um motivo para não haver testes/haver apenas testes de snapshot, descrever abaixo)
- [x] A documentação no mdx foi feita ou atualizada, caso necessário
- [x] O eslint passou localmente

### 1 - Resumo
Corrige problema que fazia com que a label do numberInput mobile ficasse acima do conteúdo

### 2 - Tipo de pull request

- [ ] 🧱 Novo componente
- [ ] ✨ Nova feature ou melhoria
- [x] 🐛 Fix
- [ ] 👨‍💻 Refatoração
- [ ] 📝 Documentação
- [ ] 🎨 Estilo
- [ ] 🤖 Build ou CI/CD


### 3 - Esse PR fecha alguma issue? Favor referenciá-la
Não

### 4 - Quais são os passos para avaliar o pull request?
- Veja se a label fica posicionada corretamente no NumberInput mobile quando o componente é inicializado com 0, string vazia ou valor nulo

### 5 - Imagem ou exemplo de uso:
<img width="462" height="53" alt="image" src="https://github.com/user-attachments/assets/dde7a7a6-5a78-445a-ad61-2ab0c35f2a18" />


### 6 - Esse pull request adiciona _breaking changes_?
- [ ] Sim
- [x] Não
