### PR TITLE
fix: corrige a emissão de evento de foco e blur em date input desativado

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sysvale/cuida",
-	"version": "3.152.0",
+	"version": "3.152.1",
 	"description": "A design system built by Sysvale, using storybook and Vue components",
 	"repository": {
 		"type": "git",

--- a/src/components/BaseInput.vue
+++ b/src/components/BaseInput.vue
@@ -77,13 +77,12 @@
 					tabindex="0"
 					v-bind="props"
 					:placeholder="placeholder"
-					:disabled="disabled"
 					:class="inputClass"
 					:type="type"
 					:autocomplete="computedAutocompleteProp"
-					@focus="handleFocus"
-					@blur="handleBlur"
-					@keydown="handleKeydown"
+					@focus="disabled && handleFocus"
+					@blur="disabled && handleBlur"
+					@keydown="disabled && handleKeydown"
 				>
 					<small class="base-input__date-text">{{ internalValue || placeholder }}</small>
 				</div>


### PR DESCRIPTION
#### Por favor, verifique se o seu pull request está de acordo com o checklist abaixo:

- [x] A implementação feita possui testes (Caso haja um motivo para não haver testes/haver apenas testes de snapshot, descrever abaixo)
- [x] A documentação no mdx foi feita ou atualizada, caso necessário
- [x] O eslint passou localmente

### 1 - Resumo
Impede a emissão do evento de foco e blur quando o date input está desativado.

### 2 - Tipo de pull request

- [ ] 🧱 Novo componente
- [ ] ✨ Nova feature ou melhoria
- [X] 🐛 Fix
- [ ] 👨‍💻 Refatoração
- [ ] 📝 Documentação
- [ ] 🎨 Estilo
- [ ] 🤖 Build ou CI/CD


### 3 - Esse PR fecha alguma issue? Favor referenciá-la
#913 

### 4 - Quais são os passos para avaliar o pull request?
1. Rode os testes do projeto com `npm run test`
2. Builde o projeto com `npm run build`
3. Acesse a documentação com `npm run docs:dev`, vá até o componente `DateInput` e verifique que os eventos de `@focus` e `@blur` não são emitidos quando o componente está desabilitado, assim como sua estilização não muda (o input continua com a estilização de input desabilitado)

### 5 - Imagem ou exemplo de uso:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/01f24b99-49d9-4ad4-97a2-4eab3205a592" />

### 6 - Esse pull request adiciona _breaking changes_?
- [ ] Sim
- [X] Não
