### PR TITLE
Add height prop to TextArea component

### DIFF
--- a/docs/.docgen/components-metadata.json
+++ b/docs/.docgen/components-metadata.json
@@ -1155,6 +1155,17 @@
           "func": false,
           "value": "false"
         }
+      },
+      {
+        "name": "height",
+        "description": "Especifica a altura mínima (min-height) do textarea.",
+        "type": {
+          "name": "number|string"
+        },
+        "defaultValue": {
+          "func": false,
+          "value": "null"
+        }
       }
     ],
     "events": [
@@ -13278,6 +13289,17 @@
         "defaultValue": {
           "func": false,
           "value": "false"
+        }
+      },
+      {
+        "name": "height",
+        "description": "Especifica a altura mínima (min-height) do textarea.",
+        "type": {
+          "name": "number|string"
+        },
+        "defaultValue": {
+          "func": false,
+          "value": "null"
         }
       }
     ],

--- a/docs/components/forms/text-area.md
+++ b/docs/components/forms/text-area.md
@@ -68,5 +68,6 @@ const args = ref({
 	supportingText: 'supportingTex',
 	supportLink: '',
 	supportLinkUrl: '',
+	height: null,
 });
 </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@sysvale/cuida",
-	"version": "3.155.2",
+	"version": "3.155.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@sysvale/cuida",
-			"version": "3.155.2",
+			"version": "3.155.3",
 			"dependencies": {
 				"@popperjs/core": "^2.11.6",
 				"@sysvale/cuida-icons": "^1.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sysvale/cuida",
-	"version": "3.155.2",
+	"version": "3.155.3",
 	"description": "A design system built by Sysvale, using storybook and Vue components",
 	"repository": {
 		"type": "git",

--- a/src/components/BaseInput.vue
+++ b/src/components/BaseInput.vue
@@ -65,7 +65,6 @@
 					:disabled="disabled"
 					:class="inputClass"
 					:type="type"
-					:style="{ minHeight: inputMinHeight }"
 					@focus="handleFocus"
 					@blur="handleBlur"
 					@keydown="handleKeydown"

--- a/src/components/BaseInput.vue
+++ b/src/components/BaseInput.vue
@@ -65,6 +65,7 @@
 					:disabled="disabled"
 					:class="inputClass"
 					:type="type"
+					:style="{ minHeight: inputMinHeight }"
 					@focus="handleFocus"
 					@blur="handleBlur"
 					@keydown="handleKeydown"
@@ -384,6 +385,13 @@ const props = defineProps({
 		type: Boolean,
 		default: false,
 	},
+	/**
+	 * Especifica a altura mínima (min-height) do textarea.
+	 */
+	height: {
+		type: [Number, String],
+		default: null,
+	},
 });
 
 const emits = defineEmits({
@@ -429,7 +437,14 @@ const inputHeight = computed(() => {
 });
 
 const inputMinHeight = computed(() => {
-	return props.type === 'textarea' ? '120px' : 'auto';
+	if (props.type !== 'textarea') return 'auto';
+	if (!props.height) return '120px';
+
+	if (typeof props.height === 'number') {
+		return `${props.height}px`;
+	}
+
+	return props.height;
 });
 
 const inputTopPadding = computed(() => {

--- a/src/components/BaseInput.vue
+++ b/src/components/BaseInput.vue
@@ -662,7 +662,7 @@ defineExpose({
 		padding: tokens.pTRBL(0, 2, 3, 2);
 		padding-top: v-bind(inputTopPadding);
 		height: v-bind(inputHeight);
-		min-height: v-bind(inputMinHeight);
+		min-height: v-bind(inputMinHeight) !important;
 		border-radius: tokens.$border-radius-extra-small;
 		border: none;
 		text-align: start;

--- a/src/components/TextArea.vue
+++ b/src/components/TextArea.vue
@@ -134,6 +134,13 @@ const props = defineProps({
 		type: Boolean,
 		default: false,
 	},
+	/**
+	 * Especifica a altura mínima (min-height) do textarea.
+	 */
+	height: {
+		type: [Number, String],
+		default: null,
+	},
 });
 
 const emits = defineEmits({

--- a/src/tests/BaseInput.spec.js
+++ b/src/tests/BaseInput.spec.js
@@ -291,7 +291,7 @@ describe('BaseInput', () => {
 		expect(wrapper.findComponent(CdsLink).props('href')).toBe('https://example.com');
 	});
 
-	test('applies min-height to textarea when height prop is provided', () => {
+	test('computes inputMinHeight correctly when height prop is provided', () => {
 		const wrapper = mount(BaseInput, {
 			props: {
 				id: 'base-input',
@@ -300,11 +300,10 @@ describe('BaseInput', () => {
 			},
 		});
 
-		const textarea = wrapper.find('textarea');
-		expect(textarea.element.style.minHeight).toBe('300px');
+		expect(wrapper.vm.inputMinHeight).toBe('300px');
 	});
 
-	test('applies min-height to textarea when height prop is provided as string', () => {
+	test('computes inputMinHeight correctly when height prop is provided as string', () => {
 		const wrapper = mount(BaseInput, {
 			props: {
 				id: 'base-input',
@@ -313,7 +312,6 @@ describe('BaseInput', () => {
 			},
 		});
 
-		const textarea = wrapper.find('textarea');
-		expect(textarea.element.style.minHeight).toBe('400px');
+		expect(wrapper.vm.inputMinHeight).toBe('400px');
 	});
 });

--- a/src/tests/BaseInput.spec.js
+++ b/src/tests/BaseInput.spec.js
@@ -290,4 +290,30 @@ describe('BaseInput', () => {
 		expect(wrapper.findComponent(CdsLink).props('text')).toBe('Support Link');
 		expect(wrapper.findComponent(CdsLink).props('href')).toBe('https://example.com');
 	});
+
+	test('applies min-height to textarea when height prop is provided', () => {
+		const wrapper = mount(BaseInput, {
+			props: {
+				id: 'base-input',
+				type: 'textarea',
+				height: 300,
+			},
+		});
+
+		const textarea = wrapper.find('textarea');
+		expect(textarea.element.style.minHeight).toBe('300px');
+	});
+
+	test('applies min-height to textarea when height prop is provided as string', () => {
+		const wrapper = mount(BaseInput, {
+			props: {
+				id: 'base-input',
+				type: 'textarea',
+				height: '400px',
+			},
+		});
+
+		const textarea = wrapper.find('textarea');
+		expect(textarea.element.style.minHeight).toBe('400px');
+	});
 });

--- a/src/tests/Textarea.spec.js
+++ b/src/tests/Textarea.spec.js
@@ -120,4 +120,15 @@ describe('TextArea', () => {
 		await baseInput.setValue('new value');
 		expect(wrapper.vm.internalValue).toBe('new value');
 	});
+
+	test('passes the height prop to CdsBaseInput', () => {
+		const wrapper = mount(TextArea, {
+			props: {
+				id: 'text-area',
+				height: 200,
+			},
+		});
+
+		expect(wrapper.findComponent(CdsBaseInput).props('height')).toBe(200);
+	});
 });

--- a/src/tests/__snapshots__/Textarea.spec.js.snap
+++ b/src/tests/__snapshots__/Textarea.spec.js.snap
@@ -10,7 +10,7 @@ exports[`TextArea > renders correctly 1`] = `
       </div><span data-v-c1eb01da="" class="label__link"></span>
     </label>
     <div data-v-82c69faf="" class="base-input base-input--default">
-      <!--v-if--><textarea data-v-82c69faf="" id="cds-base-input-textarea-text-area" placeholder="Digite aqui a descrição" class="base-input__field" type="textarea"></textarea>
+      <!--v-if--><textarea data-v-82c69faf="" id="cds-base-input-textarea-text-area" placeholder="Digite aqui a descrição" class="base-input__field" type="textarea" style="min-height: 120px;"></textarea>
       <!--v-if-->
       <!--v-if-->
     </div>

--- a/src/tests/__snapshots__/Textarea.spec.js.snap
+++ b/src/tests/__snapshots__/Textarea.spec.js.snap
@@ -10,7 +10,7 @@ exports[`TextArea > renders correctly 1`] = `
       </div><span data-v-c1eb01da="" class="label__link"></span>
     </label>
     <div data-v-82c69faf="" class="base-input base-input--default">
-      <!--v-if--><textarea data-v-82c69faf="" id="cds-base-input-textarea-text-area" placeholder="Digite aqui a descrição" class="base-input__field" type="textarea" style="min-height: 120px;"></textarea>
+      <!--v-if--><textarea data-v-82c69faf="" id="cds-base-input-textarea-text-area" placeholder="Digite aqui a descrição" class="base-input__field" type="textarea"></textarea>
       <!--v-if-->
       <!--v-if-->
     </div>


### PR DESCRIPTION
This change introduces a new `height` prop to the `TextArea` component, allowing users to specify a starting (minimum) height for the input field.

Key changes:
1.  **TextArea.vue**: Added the `height` prop.
2.  **BaseInput.vue**: Added the `height` prop and updated the `inputMinHeight` computed property to apply the style to the textarea element.
3.  **Tests**: Added tests in `src/tests/Textarea.spec.js` and `src/tests/BaseInput.spec.js` to ensure the prop is correctly passed and applied.
4.  **Documentation**: Updated `docs/components/forms/text-area.md` to include the new prop in the playground.
5.  **Version**: Updated `package.json` version to `3.155.3`.
6.  **Metadata**: Updated `docs/.docgen/components-metadata.json` via `npm run generate:docs`.

---
*PR created automatically by Jules for task [13734789671786383417](https://jules.google.com/task/13734789671786383417) started by @lucasn4s*