### PR TITLE
fix: corrige comportamento inesperado ao focar no input com tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sysvale/cuida",
-	"version": "3.156.1",
+	"version": "3.156.2",
 	"description": "A design system built by Sysvale, using storybook and Vue components",
 	"repository": {
 		"type": "git",

--- a/src/components/NumberInput.vue
+++ b/src/components/NumberInput.vue
@@ -9,10 +9,10 @@
 			:support-link="supportLink || linkText"
 			:support-link-url="supportLinkUrl || linkUrl"
 			@click="emitClick"
-			@change="handleChange"
 			@focus="handleFocus"
 			@blur="emitBlur"
 			@keydown="emitKeydown"
+			@input="handleMoneyInput"
 		/>
 
 		<CdsBaseInput
@@ -51,13 +51,13 @@
 </template>
 
 <script setup>
-import { ref, watch, onMounted, useTemplateRef } from 'vue';
-import {
-	nativeEvents,
-	nativeEmits,
-} from '../utils/composables/useComponentEmits.js';
-import { vCdsBrl, unmaskBRL } from '../utils/directives/cdsBRL';
+import { nextTick, ref, useTemplateRef, watch } from 'vue';
 import { facade } from 'vue-input-facade';
+import {
+	nativeEmits,
+	nativeEvents,
+} from '../utils/composables/useComponentEmits.js';
+import { unmaskBRL } from '../utils/directives/cdsBRL';
 import CdsBaseInput from './BaseInput.vue';
 
 defineOptions({ name: 'CdsNumberInput' });
@@ -229,98 +229,88 @@ const emits = defineEmits({
 /* REACTIVE DATA */
 const internalValue = ref('');
 const { emitClick, emitChange, emitFocus, emitBlur, emitKeydown } = nativeEmits(emits);
-let cdsBrlBiding = {};
-
-
-/* WATCHERS */
-watch(model, (newValue, oldValue) => {
-	if (newValue === oldValue) return;
-	
-	if (!props.money) {
-		internalValue.value = newValue;
-		return;
-	}
-
-	if (!newValue) {
-		internalValue.value = `R$ 0,00`;
-		return;
-	}
-	
-	if (typeof newValue === 'number') {
-		internalValue.value = `R$ ${newValue.toFixed(2).replace('.', ',')}`;
-		return;
-	}
-	
-	if (typeof newValue === 'string' && newValue.startsWith('R$')) {
-		internalValue.value = newValue;
-		return;
-	}
-	
-	const parsed = parseFloat(newValue);
-	internalValue.value = isNaN(parsed)
-		? `R$ ${newValue.replace('.', ',')}`
-		: parsed.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
-}, {immediate: true});
-
-watch(internalValue, (value, oldValue) => {
-	if (value !== oldValue) {
-		let stringifiedInput = String(value);
-
-		if (props.money) {
-			/**
-			* Evento utilizado para implementar o v-model para atualização
-			* de valores sem máscara de dinheiro.
-			* @event update:unmaskedValue
-			* @type {Event}
-			*/
-			unmaskedValue.value = unmaskBRL(stringifiedInput);
-			/**
-			* Evento utilizado para implementar o v-model padrão do componente.
-			* @event update:modelValue
-			* @type {Event}
-			*/
-			model.value = stringifiedInput;
-		} else if (props.mask) {
-			internalValue.value = stringifiedInput;
-			model.value = stringifiedInput;
-			unmaskedValue.value = +stringifiedInput.replace(/\D/g, '');
-		} else if (stringifiedInput.length > 15) {
-			internalValue.value = +stringifiedInput.slice(0, 15);
-		} else {
-			model.value = +stringifiedInput;
-			unmaskedValue.value = +stringifiedInput;
-		}
-	}
-});
-
-/* HOOKS */
-onMounted(() => {
-	if (props.money && baseInputRef.value && baseInputRef.value.componentRef) {
-		cdsBrlBiding =  {
-			value: model.value,
-			oldValue: '',
-			instance: baseInputRef.value.componentRef,
-			modifiers: {},
-			arg: null,
-		};
-		vCdsBrl.mounted(baseInputRef.value.componentRef, cdsBrlBiding);
-	}
-});
 
 /* FUNCTIONS */
-function handleFocus() {
+function formatToBRL(value) {
+	if (typeof value === 'number') {
+		return value.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+	}
+	
+	const onlyNumbers = String(value || '').replace(/\D/g, '');
+	if (!onlyNumbers) return 'R$ 0,00';
+	
+	const number = parseFloat(onlyNumbers) / 100;
+	return number.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+}
+function handleMoneyInput(event) {
+	const digits = event.target.value.replace(/\D/g, '');
+
+	const formattedValue = formatToBRL(digits);
+
+	
+	internalValue.value = formattedValue;
+	unmaskedValue.value = unmaskBRL(formattedValue);
+	model.value = formattedValue;
+
+	/*
+	*  Dadas as diferenças entre as engines do Chrome e Firefox
+	*  essa validação foi adicionada para forçar a renderização do DOM
+	*  e evitar que o valor padrão (R$ 0,00) pudesse ser visualmente
+	*  alterado para R$ 0,0 no Firefox.
+	*/
+	if (event.target.value !== formattedValue) {
+		nextTick(() => {
+			event.target.value = formattedValue;
+		});
+	}
+}
+
+function handleFocus(event) {
 	if (props.money) {
-		internalValue.value = (internalValue.value == 0 || internalValue.value == '') 
+		internalValue.value = (internalValue.value === 0 || internalValue.value === '')
 			? 'R$ 0,00'
 			: internalValue.value;
+
+		setTimeout(() => {
+			baseInputRef.value?.select();
+		}, 0);
 	}
-	emitFocus();
+	emitFocus(event);
 }
 
 function handleChange() {
-	model.value = internalValue.value;
+	if (!props.money) {
+		model.value = internalValue.value;
+	}
 	emitChange();
 }
+
+/* WATCHERS */
+watch(model, (newValue) => {
+	if (props.money) {
+		const formatted = formatToBRL(newValue);
+		internalValue.value = formatted;
+		unmaskedValue.value = unmaskBRL(formatted);
+	} else {
+		internalValue.value = newValue ?? '';
+	}
+}, { immediate: true });
+
+watch(internalValue, (value) => {
+	if (props.money) return;
+
+	let stringifiedInput = String(value);
+
+	if (props.mask) {
+		model.value = stringifiedInput;
+		unmaskedValue.value = +stringifiedInput.replace(/\D/g, '');
+	} else if (stringifiedInput.length > 15) {
+		internalValue.value = +stringifiedInput.slice(0, 15);
+	} else {
+		model.value = +stringifiedInput;
+		unmaskedValue.value = +stringifiedInput;
+	}
+});
 
 /* EXPOSE */
 defineExpose({

--- a/src/components/NumberInput.vue
+++ b/src/components/NumberInput.vue
@@ -230,22 +230,73 @@ const emits = defineEmits({
 const internalValue = ref('');
 const { emitClick, emitChange, emitFocus, emitBlur, emitKeydown } = nativeEmits(emits);
 
-/* FUNCTIONS */
-function formatToBRL(value) {
-	if (typeof value === 'number') {
-		return value.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+/* WATCHERS */
+watch(model, (newValue) => {
+	if (props.money) {
+		if (newValue === null || newValue === undefined || newValue === '') {
+			internalValue.value = 'R$ 0,00';
+			unmaskedValue.value = 0;
+			return;
+		}
+
+		if (typeof newValue === 'number') {
+			const formatted = newValue.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+			internalValue.value = formatted;
+			unmaskedValue.value = newValue;
+			return;
+		}
+
+		if (typeof newValue === 'string') {
+			if (newValue.startsWith('R$')) {
+				internalValue.value = newValue;
+				unmaskedValue.value = unmaskBRL(newValue);
+				return;
+			}
+			
+			const parsed = parseFloat(newValue.replace(',', '.'));
+			if (!isNaN(parsed)) {
+				const formatted = parsed.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+				internalValue.value = formatted;
+				unmaskedValue.value = parsed;
+			} else {
+				internalValue.value = 'R$ 0,00';
+				unmaskedValue.value = 0;
+			}
+		}
+	} else {
+		internalValue.value = newValue ?? '';
 	}
-	
-	const onlyNumbers = String(value || '').replace(/\D/g, '');
+}, { immediate: true });
+
+watch(internalValue, (value) => {
+	if (props.money) return;
+
+	let stringifiedInput = String(value);
+
+	if (props.mask) {
+		model.value = stringifiedInput;
+		unmaskedValue.value = +stringifiedInput.replace(/\D/g, '');
+	} else if (stringifiedInput.length > 15) {
+		internalValue.value = +stringifiedInput.slice(0, 15);
+	} else {
+		model.value = +stringifiedInput;
+		unmaskedValue.value = +stringifiedInput;
+	}
+});
+
+/* FUNCTIONS */
+function formatDigitsToBRL(digits) {
+	const onlyNumbers = String(digits || '').replace(/\D/g, '');
 	if (!onlyNumbers) return 'R$ 0,00';
 	
 	const number = parseFloat(onlyNumbers) / 100;
 	return number.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
 }
+
 function handleMoneyInput(event) {
 	const digits = event.target.value.replace(/\D/g, '');
 
-	const formattedValue = formatToBRL(digits);
+	const formattedValue = formatDigitsToBRL(digits);
 
 	
 	internalValue.value = formattedValue;
@@ -267,7 +318,7 @@ function handleMoneyInput(event) {
 
 function handleFocus(event) {
 	if (props.money) {
-		internalValue.value = (internalValue.value === 0 || internalValue.value === '')
+		internalValue.value = (internalValue.value === '')
 			? 'R$ 0,00'
 			: internalValue.value;
 
@@ -284,33 +335,6 @@ function handleChange() {
 	}
 	emitChange();
 }
-
-/* WATCHERS */
-watch(model, (newValue) => {
-	if (props.money) {
-		const formatted = formatToBRL(newValue);
-		internalValue.value = formatted;
-		unmaskedValue.value = unmaskBRL(formatted);
-	} else {
-		internalValue.value = newValue ?? '';
-	}
-}, { immediate: true });
-
-watch(internalValue, (value) => {
-	if (props.money) return;
-
-	let stringifiedInput = String(value);
-
-	if (props.mask) {
-		model.value = stringifiedInput;
-		unmaskedValue.value = +stringifiedInput.replace(/\D/g, '');
-	} else if (stringifiedInput.length > 15) {
-		internalValue.value = +stringifiedInput.slice(0, 15);
-	} else {
-		model.value = +stringifiedInput;
-		unmaskedValue.value = +stringifiedInput;
-	}
-});
 
 /* EXPOSE */
 defineExpose({

--- a/src/tests/NumberInput.spec.js
+++ b/src/tests/NumberInput.spec.js
@@ -1,9 +1,8 @@
-import { describe, test, expect } from 'vitest';
+import { describe, test, expect, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
+import { nextTick } from 'vue';
 import CdsNumberInput from '../components/NumberInput.vue';
 import CdsBaseInput from '../components/BaseInput.vue';
-import { vCdsBrl } from '../utils/directives/cdsBRL';
-
 
 describe('CdsNumberInput', () => {
 	test('renders correctly', () => {
@@ -85,24 +84,60 @@ describe('CdsNumberInput', () => {
 
 	test('applies money mask and updates internal state correctly', async () => {
 		const wrapper = mount(CdsNumberInput, {
-			global: {
-				directives: {
-					CdsBrl: vCdsBrl, // Registre a diretiva
-				},
-			},
 			props: {
 				id: 'number-input',
 				money: true,
+				modelValue: 0,
 			},
 		});
 
-		await wrapper.vm.$nextTick();
-
 		const input = wrapper.find('input');
 
-		await input.setValue('123456');
+		input.element.value = '123456';
+		await input.trigger('input');
 
 		expect(wrapper.vm.model).toMatch(/R\$[\s\u00A0]1\.234,56/);
 		expect(wrapper.vm.unmaskedValue).toBe(1234.56);
+	});
+
+	test('should select all text on focus when money prop is true', async () => {
+		vi.useFakeTimers();
+		const wrapper = mount(CdsNumberInput, {
+			props: {
+				id: 'number-input',
+				money: true,
+				modelValue: 50,
+			},
+		});
+
+		const baseInput = wrapper.findComponent({ ref: 'baseInput' });
+		const selectSpy = vi.spyOn(baseInput.vm, 'select');
+
+		const input = wrapper.find('input');
+		await input.trigger('focus');
+
+		vi.runAllTimers();
+
+		expect(selectSpy).toHaveBeenCalled();
+		vi.useRealTimers();
+	});
+
+	test('should keep R$ 0,00 when trying to delete characters in Firefox-like scenario', async () => {
+		const wrapper = mount(CdsNumberInput, {
+			props: {
+				money: true,
+				modelValue: 0,
+			},
+		});
+
+		const input = wrapper.find('input');
+		
+		input.element.value = 'R$ 0,0';
+		await input.trigger('input');
+		
+		await nextTick();
+		await nextTick();
+
+		expect(input.element.value).toMatch(/R\$[\s\u00A0]0,00/);
 	});
 });


### PR DESCRIPTION
### 1 - Resumo
Em navegadores baseados no Chrome, ao focar no NumberInput via Tab e digitar um valor esse valor era colocado no primeiro dígito antes da vírgula e não no último digito da máscara. Além disso, em navegadores baseados no Firefox, era
possível apagar o último dígito do valor padrão (R$ 0,00), fazendo com que o valor visual do input ficasse R$ 0,0. 

### 2 - Tipo de pull request

- [ ] 🧱 Novo componente
- [ ] ✨ Nova feature ou melhoria
- [X] 🐛 Fix
- [ ] 👨‍💻 Refatoração
- [ ] 📝 Documentação
- [ ] 🎨 Estilo
- [ ] 🤖 Build ou CI/CD


### 3 - Esse PR fecha alguma issue? Favor referenciá-la
Não

### 4 - Quais são os passos para avaliar o pull request?
**Consegui reproduzir o comportamento em navegadores baseados no Chrome**

- Vá para a página da documentação do NumberInput e selecione o input utilizando Tab
- Digite um valor e verifique que, ao invés do valor digitado ficar ao fim da máscara ele ocupa o primeiro dígito antes da vírgula (ex: o que era pra ser R$ 0,09 fica R$ 9,00)
- Com as alterações, verifique que o comportamento acima não e repete

**Agora, em navegadores baseados no Firefox**
- Ainda na página do NumberInput tente apagar o último 0 que fica no valor padrão do input (R$ 0,00)
- Verifique que é possível fazer isso, fazendo com que a máscara fique R$ 0,0
- Com as mudanças verifique que isso não ocorre

### 5 - Imagem ou exemplo de uso:
[Gravação de tela de 2026-04-28 15-49-26.webm](https://github.com/user-attachments/assets/2e5bf526-c5c7-46d8-8a86-038d8caa188e)

### 6 - Esse pull request adiciona _breaking changes_?
- [ ] Sim
- [X] Não
