### PR TITLE
Permite gerenciar o select usando o teclado

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sysvale/cuida",
-	"version": "3.156.1",
+	"version": "3.158.0",
 	"description": "A design system built by Sysvale, using storybook and Vue components",
 	"repository": {
 		"type": "git",

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -60,7 +60,7 @@
 						]"
 						@mousedown="selectItem(index)"
 						@mouseover="highlightOnMouseOver(index)"
-						@mouseout="currentPos = -1"
+						@mouseout="syncCurrentPos()"
 					>
 						<!--
 							@slot Slot utilizado para personalizar a lista de opções do select. Os dados do scoped slot podem ser acessados como: ```slot-scope={ 'option', 'index', 'value' }```

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -566,6 +566,7 @@ function activateSelectionOnEnter() {
 	searchString.value = '';
 	isTyping.value = false;
 	active.value = false;
+	localOptions.value = pristineOptions.value;
 
 	nextTick(() => {
 		isSelectingItem = false;
@@ -587,6 +588,8 @@ function activateSelectionOnClick() {
 
 	if (active.value) {
 		syncCurrentPos();
+	} else {
+		localOptions.value = pristineOptions.value;
 	}
 
 	emitClick();
@@ -713,14 +716,6 @@ function highlightOnArrowUp() {
 
 function highlightOnMouseOver(index) {
 	currentPos.value = index;
-}
-
-function unhighlightOnMouseOut() {
-	// A lógica de remoção de classe agora é reativa via currentPos.
-}
-
-function resetActiveSelection() {
-	// Não é mais necessário com a abordagem reativa.
 }
 
 function handleAddOption() {

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -462,7 +462,7 @@ function filterOptions(value) {
 		simpleOptionSearch(sanitizedString);
 	}
 
-	currentPos.value = 0;
+	currentPos.value = localOptions.value.length > 0 ? 0 : -1;
 }
 
 function simpleOptionSearch(sanitizedSearchValue) {

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -446,10 +446,6 @@ function filterOptions(value) {
 		return;
 	}
 
-	if (props.searchable && !active.value) {
-		active.value = true;
-	}
-
 	if (props.searchable && props.addable) {
 		searchString.value = value;
 	}

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -646,23 +646,19 @@ function getLiInDOM(position) {
 	return liRefs.value[`${element[props.optionsField]}-${position}`];
 }
 
-function handleOptionVisibility(option, amount, direction) {
-	const optionDOMRect = option.getBoundingClientRect();
+function handleOptionVisibility(option) {
 	const optionsContainer = selectOptions.value;
-	const optionsContainerDOMRect = optionsContainer.getBoundingClientRect();
+	const optionTop = option.offsetTop;
+	const optionBottom = optionTop + option.offsetHeight;
+	const containerTop = optionsContainer.scrollTop;
+	const containerBottom = containerTop + optionsContainer.clientHeight;
 
-	if (
-		direction === 'up'
-		&& optionDOMRect.top <= optionsContainerDOMRect.top
-	) {
-		optionsContainer.scrollTop += amount;
+	if (optionTop < containerTop) {
+		optionsContainer.scrollTop = optionTop;
 	}
 
-	if (
-		direction === 'down'
-		&& optionDOMRect.top >= optionsContainerDOMRect.bottom
-	) {
-		optionsContainer.scrollTop += amount;
+	if (optionBottom > containerBottom) {
+		optionsContainer.scrollTop = optionBottom - optionsContainer.clientHeight;
 	}
 }
 
@@ -680,11 +676,12 @@ function highlightOnArrowDown() {
 	if (currentPos.value === localOptions.value.length - 1) return;
 
 	currentPos.value += 1;
+	localValue.value = cloneDeep(localOptions.value[currentPos.value]);
 
 	nextTick(() => {
 		const selectedOption = getLiInDOM(currentPos.value);
 		if (selectedOption) {
-			handleOptionVisibility(selectedOption, 37, 'down');
+			handleOptionVisibility(selectedOption);
 		}
 	});
 }
@@ -703,11 +700,12 @@ function highlightOnArrowUp() {
 	if (currentPos.value <= 0) return;
 
 	currentPos.value -= 1;
+	localValue.value = cloneDeep(localOptions.value[currentPos.value]);
 
 	nextTick(() => {
 		const selectedOption = getLiInDOM(currentPos.value);
 		if (selectedOption) {
-			handleOptionVisibility(selectedOption, -37, 'up');
+			handleOptionVisibility(selectedOption);
 		}
 	});
 }
@@ -902,10 +900,12 @@ defineExpose({
 		}
 
 		&--up {
+			width: 100%;
 			bottom: 40px;
 		}
 
 		&--down {
+			width: 100%;
 		}
 	}
 }
@@ -944,7 +944,7 @@ defineExpose({
 
 		&--selected {
 			background-color: tokens.$n-30;
-			font-weight: tokens.$font-weight-semibold;
+			// font-weight: tokens.$font-weight-semibold;
 		}
 	}
 

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -530,9 +530,10 @@ function handleKeydown(event) {
 			if (props.searchable && !active.value && event.key.length === 1) {
 				active.value = true;
 			}
-			emitKeydown(event);
 			break;
 	}
+
+	emitKeydown(event);
 }
 
 function activateSelectionOnEnter() {

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -17,17 +17,14 @@
 				:onkeypress="`return ${allowSearch};`"
 				:placeholder="placeholder"
 				:disabled="disabled"
-				:readonly="!searchable || !active"
+				:readonly="!searchable"
 				:support-link-url="supportLinkUrl || linkUrl"
 				:support-link="supportLink || linkText"
 				:floating-label="floatingLabel || mobile"
 				:class="inputClass"
 				:fluid="computedFluid"
 				:ghost
-				@keydown.enter.prevent="activateSelectionOnEnter"
-				@keydown.arrow-down.prevent="highlightOnArrowDown"
-				@keydown.arrow-up.prevent="highlightOnArrowUp"
-				@keydown="emitKeydown"
+				@keydown="handleKeydown"
 				@click="activateSelectionOnClick"
 				@update:model-value="filterOptions"
 				@focus="activeSelection"
@@ -54,10 +51,16 @@
 						v-for="(option, index) in localOptions"
 						:key="option.id || option"
 						:ref="(el) => { liRefs[`${option[optionsField]}-${index}`] = el }"
-						class="option__text"
-						@mousedown="selectItem"
+						:class="[
+							'option__text',
+							{
+								highlight: index === currentPos,
+								'option__text--selected': isSelected(option)
+							}
+						]"
+						@mousedown="selectItem(index)"
 						@mouseover="highlightOnMouseOver(index)"
-						@mouseout="unhighlightOnMouseOut()"
+						@mouseout="currentPos = -1"
 					>
 						<!--
 							@slot Slot utilizado para personalizar a lista de opções do select. Os dados do scoped slot podem ser acessados como: ```slot-scope={ 'option', 'index', 'value' }```
@@ -306,16 +309,13 @@ const emits = defineEmits({
 });
 
 /* REACTIVE DATA */
-const currentPos = ref(0);
+const currentPos = ref(-1);
 const active = ref(false);
 const id = ref(null);
 const allowSearch = ref(false);
 const localOptions = ref([]);
 const pristineOptions = ref([]);
-const localValue = ref({
-	value: '',
-	id: '',
-});
+const localValue = ref({});
 const selectElement = ref('');
 const direction = ref('down');
 const uniqueKey = ref(generateKey());
@@ -413,6 +413,8 @@ watch(model, (newValue, oldValue) => {
 }, { immediate: true });
 
 watch(localValue, (currentValue) => {
+	syncCurrentPos();
+
 	if (JSON.stringify(currentValue) === JSON.stringify(model.value)) return;
 
 	const isValueEmpty = !currentValue || (typeof currentValue === 'object' && Object.keys(currentValue).length === 0);
@@ -444,6 +446,10 @@ function filterOptions(value) {
 		return;
 	}
 
+	if (props.searchable && !active.value) {
+		active.value = true;
+	}
+
 	if (props.searchable && props.addable) {
 		searchString.value = value;
 	}
@@ -455,6 +461,8 @@ function filterOptions(value) {
 	} else {
 		simpleOptionSearch(sanitizedString);
 	}
+
+	currentPos.value = 0;
 }
 
 function simpleOptionSearch(sanitizedSearchValue) {
@@ -480,43 +488,83 @@ function deepOptionSearch(sanitizedSearchValue) {
 function activeSelection() {
 	if (props.disabled) return;
 
-	resetActiveSelection();
-
-	nextTick().then(() => {
-		const element = localOptions.value[currentPos.value];
-		liRefs.value[`${get(element, props.optionsField)}-${currentPos.value}`]?.classList.add('highlight');
-	});
+	syncCurrentPos();
 	emitFocus();
+}
+
+function syncCurrentPos() {
+	const valueToFind = get(localValue.value, props.optionsField);
+	const index = localOptions.value.findIndex(option => option[props.optionsField] === valueToFind);
+
+	if (index !== -1) {
+		currentPos.value = index;
+	} else {
+		currentPos.value = -1;
+	}
+}
+
+function handleKeydown(event) {
+	if (props.disabled) return;
+
+	switch (event.key) {
+		case 'Enter':
+			event.preventDefault();
+			activateSelectionOnEnter();
+			break;
+		case 'ArrowDown':
+		case 'Down':
+			event.preventDefault();
+			highlightOnArrowDown();
+			break;
+		case 'ArrowUp':
+		case 'Up':
+			event.preventDefault();
+			highlightOnArrowUp();
+			break;
+		case 'Escape':
+		case 'Esc':
+			active.value = false;
+			select.value.blur();
+			break;
+		default:
+			if (props.searchable && !active.value && event.key.length === 1) {
+				active.value = true;
+			}
+			emitKeydown(event);
+			break;
+	}
 }
 
 function activateSelectionOnEnter() {
 	if (props.disabled) return;
 
-	if (localOptions.value.length === 0 && !(props.searchable && props.addable)) {
-		active.value = false;
-		isTyping.value = false;
-		select.value.blur();
+	if (!active.value) {
+		active.value = true;
+		syncCurrentPos();
 		return;
 	}
 
-	active.value = !active.value;
+	if (localOptions.value.length === 0 && !(props.searchable && props.addable)) {
+		active.value = false;
+		isTyping.value = false;
+		return;
+	}
+
 	isSelectingItem = true;
 
-	resetActiveSelection();
-
-	if (typeof localOptions.value[currentPos.value] === 'undefined') {
-		handleAddOption();
-
-		localValue.value = props.searchable && props.addable
-			? localValue.value
-			: localOptions.value.length ? cloneDeep(localOptions.value[0]) : {};
+	if (currentPos.value === -1 || typeof localOptions.value[currentPos.value] === 'undefined') {
+		if (props.searchable && props.addable) {
+			handleAddOption();
+		} else {
+			localValue.value = localOptions.value.length ? cloneDeep(localOptions.value[0]) : {};
+		}
 	} else {
 		localValue.value = cloneDeep(localOptions.value[currentPos.value]);
 	}
 
 	searchString.value = '';
 	isTyping.value = false;
-	select.value.blur();
+	active.value = false;
 
 	nextTick(() => {
 		isSelectingItem = false;
@@ -535,6 +583,10 @@ function activateSelectionOnClick() {
 	if (props.disabled) return;
 
 	active.value = !active.value;
+
+	if (active.value) {
+		syncCurrentPos();
+	}
 
 	emitClick();
 	select.value.focus();
@@ -561,25 +613,35 @@ function hide() {
 		active.value = false;
 		isTyping.value = false;
 		isSelectingItem = false;
+		currentPos.value = -1;
 	});
 
 	emitBlur();
 }
 
-function selectItem() {
+function selectItem(index) {
+	const position = (typeof index === 'number') ? index : currentPos.value;
+	if (position === -1 || !localOptions.value[position]) return;
+
 	isSelectingItem = false;
 	searchString.value = '';
-	localValue.value = cloneDeep(localOptions.value[currentPos.value]);
+	localValue.value = cloneDeep(localOptions.value[position]);
 	active.value = false;
 	isTyping.value = false;
 	select.value.blur();
 
 	nextTick(() => {
 		isSelectingItem = false;
+		currentPos.value = -1;
 	});
 }
 
+function isSelected(option) {
+	return option[props.optionsField] === localValue.value?.[props.optionsField];
+}
+
 function getLiInDOM(position) {
+	if (position < 0 || position >= localOptions.value.length) return null;
 	const element = localOptions.value[position];
 	return liRefs.value[`${element[props.optionsField]}-${position}`];
 }
@@ -605,47 +667,61 @@ function handleOptionVisibility(option, amount, direction) {
 }
 
 function highlightOnArrowDown() {
-	if (!active.value) return;
+	if (props.disabled) return;
+
+	if (!active.value) {
+		if (currentPos.value < localOptions.value.length - 1) {
+			currentPos.value += 1;
+			localValue.value = cloneDeep(localOptions.value[currentPos.value]);
+		}
+		return;
+	}
+
 	if (currentPos.value === localOptions.value.length - 1) return;
 
 	currentPos.value += 1;
-	const selectedOption = getLiInDOM(currentPos.value);
-	const previousOption = getLiInDOM(currentPos.value - 1);
 
-	selectedOption.classList.add('highlight');
-	previousOption.classList.remove('highlight');
-
-	handleOptionVisibility(selectedOption, 37, 'down');
+	nextTick(() => {
+		const selectedOption = getLiInDOM(currentPos.value);
+		if (selectedOption) {
+			handleOptionVisibility(selectedOption, 37, 'down');
+		}
+	});
 }
 
 function highlightOnArrowUp() {
-	if (!active.value) return;
-	if (currentPos.value === 0) return;
+	if (props.disabled) return;
 
-	const selectedOption = getLiInDOM(currentPos.value);
-	const previousOption = getLiInDOM(currentPos.value - 1);
+	if (!active.value) {
+		if (currentPos.value > 0) {
+			currentPos.value -= 1;
+			localValue.value = cloneDeep(localOptions.value[currentPos.value]);
+		}
+		return;
+	}
 
-	selectedOption.classList.remove('highlight');
-	previousOption.classList.add('highlight');
+	if (currentPos.value <= 0) return;
 
-	handleOptionVisibility(selectedOption, -37, 'up');
 	currentPos.value -= 1;
+
+	nextTick(() => {
+		const selectedOption = getLiInDOM(currentPos.value);
+		if (selectedOption) {
+			handleOptionVisibility(selectedOption, -37, 'up');
+		}
+	});
 }
 
 function highlightOnMouseOver(index) {
 	currentPos.value = index;
-	getLiInDOM(currentPos.value).classList.add('highlight');
 }
 
 function unhighlightOnMouseOut() {
-	getLiInDOM(currentPos.value).classList.remove('highlight');
+	// A lógica de remoção de classe agora é reativa via currentPos.
 }
 
 function resetActiveSelection() {
-	localOptions.value.forEach((option, index) => {
-		const element = localOptions.value[index];
-		liRefs.value[`${element[props.optionsField]}-${index}`].classList.remove('highlight');
-	})
+	// Não é mais necessário com a abordagem reativa.
 }
 
 function handleAddOption() {
@@ -827,11 +903,9 @@ defineExpose({
 
 		&--up {
 			bottom: 40px;
-			width: 100%;
 		}
 
 		&--down {
-			width: 100%;
 		}
 	}
 }
@@ -861,10 +935,16 @@ defineExpose({
 	&__text {
 		padding: tokens.pa(3);
 		text-overflow: ellipsis;
+		transition: all 100ms ease-in-out;
 
 		&--muted {
 			@extend .option__text;
 			color: tokens.$n-400;
+		}
+
+		&--selected {
+			background-color: tokens.$n-30;
+			font-weight: tokens.$font-weight-semibold;
 		}
 	}
 
@@ -875,8 +955,8 @@ defineExpose({
 	}
 }
 
-.highlight{
-	background-color: tokens.$n-10;
+.highlight {
+	background-color: tokens.$n-30;
 	cursor: pointer;
 }
 


### PR DESCRIPTION
#### Por favor, verifique se o seu pull request está de acordo com o checklist abaixo:

- [x] A implementação feita possui testes (Caso haja um motivo para não haver testes/haver apenas testes de snapshot, descrever abaixo)
- [x] A documentação no mdx foi feita ou atualizada, caso necessário
- [x] O eslint passou localmente

### 1 - Resumo
 - Implementa o gerenciamento do select por teclado

### 2 - Tipo de pull request

- [ ] 🧱 Novo componente
- [ x] ✨ Nova feature ou melhoria
- [ ] 🐛 Fix
- [ ] 👨‍💻 Refatoração
- [ ] 📝 Documentação
- [ ] 🎨 Estilo
- [ ] 🤖 Build ou CI/CD


### 3 - Esse PR fecha alguma issue? Favor referenciá-la

### 4 - Quais são os passos para avaliar o pull request?
- Utilize o teclado para selecionar as opções do campo de seleção (select), preferencialmente;
- Teste com todas as _props_ ativadas e desativadas;
- Veja que agora é possível gerenciar o campo de seleção apenas com as teclas, semelhante ao comportamento do campo de seleção do HTML;
    - É possível selecionar as opções através das setas direcionais do teclado;
    - Ao teclar Enter quando o campo de seleção estiver em focus, as opções são abertas
    - Quando a opção `searchable` estiver ativa, pressionar qualquer tecla, filtra as opções. E se a _prop_ estiver ativa, pressionar Enter adiciona o texto como nova opção (semelhante ao que já acontecia) 

### 5 - Imagem ou exemplo de uso:

### 6 - Esse pull request adiciona _breaking changes_?
- [ ] Sim
- [ ] Não
