### PR TITLE
feat: adicionar negrito às opções destacadas

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sysvale/cuida",
-	"version": "3.156.0",
+	"version": "3.157.0",
 	"description": "A design system built by Sysvale, using storybook and Vue components",
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sysvale/cuida",
-	"version": "3.155.2",
+	"version": "3.156.0",
 	"description": "A design system built by Sysvale, using storybook and Vue components",
 	"repository": {
 		"type": "git",

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -679,10 +679,6 @@ defineExpose({
 .select {
 	width: v-bind(selectContainerWidth);
 
-	:deep(input::placeholder) {
-		font-weight: 400; 
-	}
-
 	&__input {
 		&--searchable {
 			caret-color: tokens.$n-700;
@@ -882,7 +878,7 @@ defineExpose({
 .highlight{
 	background-color: tokens.$n-10;
 	cursor: pointer;
-	font-weight: tokens.$font-weight-bold;
+	font-weight: tokens.$font-weight-semibold;
 }
 
 .add-button-searchstring {

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -678,6 +678,9 @@ defineExpose({
 
 .select {
 	width: v-bind(selectContainerWidth);
+		:deep(input::placeholder) {
+			font-weight: 400 !important;
+		}
 
 	&__input {
 		&--searchable {
@@ -878,6 +881,7 @@ defineExpose({
 .highlight{
 	background-color: tokens.$n-10;
 	cursor: pointer;
+	font-weight: tokens.$font-weight-bold;
 }
 
 .add-button-searchstring {

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -678,9 +678,10 @@ defineExpose({
 
 .select {
 	width: v-bind(selectContainerWidth);
-		:deep(input::placeholder) {
-			font-weight: 400 !important;
-		}
+
+	:deep(input::placeholder) {
+		font-weight: 400; 
+	}
 
 	&__input {
 		&--searchable {


### PR DESCRIPTION
Este Pull Request introduz uma melhoria de UX no componente CdsSelect, focada em fornecer um feedback visual mais robusto durante a interação com a lista de opções. Através da aplicação do token de negrito (font-weight-bold) na classe .highlight, o item sob o cursor do mouse ou foco do teclado ganha um destaque imediato, facilitando a navegação. Importante ressaltar que essa alteração foi implementada de forma a não afetar o campo principal após a seleção, garantindo que o texto retorne ao peso padrão para manter a harmonia visual com o label e evitar sobrecarga estética. A validação pode ser feita via documentação local, observando a alternância do peso da fonte durante o hover na lista e a persistência do estilo original no input após o fechamento do dropdown.