### PR TITLE
fix(sidebar): expandir área de clique e corrigir emissão de evento no…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sysvale/cuida",
-	"version": "3.157.0",
+	"version": "3.157.1",
 	"description": "A design system built by Sysvale, using storybook and Vue components",
 	"repository": {
 		"type": "git",

--- a/src/components/SideBar.vue
+++ b/src/components/SideBar.vue
@@ -107,7 +107,7 @@
 							:to="routerPushTo(item)"
 							class="side-bar__item"
 							:class="isActive(item) ? 'side-bar__item--active' : 'side-bar__item--inactive'"
-							@click="(event) => handleClick(event, item)"
+							@click.stop="(event) => handleClick(event, item)"
 						>
 							<div>
 								<CdsIcon
@@ -532,6 +532,7 @@ function handleClick(event, item) {
 		internalActiveItem.value = item;
 		showUncollapsedItems.value = true;
 		expandItemControl.value += 1;
+		emit('sidebar-click', internalActiveItem.value);
 		return;
 	}
 
@@ -736,6 +737,8 @@ defineExpose({
 
 		&__item-container {
 			cursor: pointer !important;
+			display: flex;
+			align-items: center;
 
 			&--active {
 				background-color: tokens.$n-600;
@@ -755,6 +758,7 @@ defineExpose({
 				border-radius: tokens.$border-radius-extra-small;
 				padding: tokens.pTRBL(3, 4, 3, 4);
 				transition: tokens.$opening;
+				width: 100%;
 			}
 		}
 
@@ -780,6 +784,7 @@ defineExpose({
 			text-overflow: ellipsis;
 			text-align: center;
 			text-decoration: none !important;
+			width: 100%;
 
 			&--active {
 				color: tokens.$n-0;


### PR DESCRIPTION
## fix(sidebar): expand click area and fix event emit on first click

#### Por favor, verifique se o seu pull request está de acordo com o checklist abaixo:
- [x] A implementação feita possui testes (Caso haja um motivo para não haver testes/haver apenas testes de snapshot, descrever abaixo)
- [x] A documentação no mdx foi feita ou atualizada, caso necessário
- [x] O eslint passou localmente

### 1 - Resumo
Corrige dois bugs no componente `CdsSideBar`:

1. **Área clicável restrita** : o elemento `side-bar__item` não possuía `width: 100%`, fazendo com que a área clicável ficasse limitada ao tamanho do ícone e do texto. Cliques no espaço ao redor do item não funcionavam.

2. **Primeiro clique sem navegação** : ao clicar em um item diferente do ativo, o `handleClick` atualizava o estado interno mas retornava sem emitir o evento `sidebar-click`, fazendo com que a navegação só ocorresse no segundo clique.

### 2 - Tipo de pull request
- [ ] 🧱 Novo componente
- [ ] ✨ Nova feature ou melhoria
- [x] 🐛 Fix
- [ ] 👨‍💻 Refatoração
- [ ] 📝 Documentação
- [ ] 🎨 Estilo
- [ ] 🤖 Build ou CI/CD

### 3 - Esse PR fecha alguma issue? Favor referenciá-la
N/A

### 4 - Quais são os passos para avaliar o pull request?
1. Renderizar o componente `CdsSideBar` com múltiplos itens
2. Clicar em um item inativo **fora do ícone** (no espaço ao redor) deve navegar normalmente
3. Clicar em um item diferente do atual, deve emitir `@sidebar-click` já no **primeiro clique**
4. Verificar que não há duplo disparo de eventos ao clicar em qualquer área do item

### 5 - Imagem ou exemplo de uso:
N/A

### 6 - Esse pull request adiciona _breaking changes_?
- [ ] Sim
- [x] Não