### PR TITLE
Permite que o usuário redimensione apenas o input do tipo textarea

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,6 +1,7 @@
 name: 'Build docs 📚'
 permissions:
   contents: read
+  actions: read
 
 on: [push]
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,7 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  actions: read
 
 concurrency:
   group: pages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,7 @@ on:
 permissions:
   id-token: write
   contents: read
+  actions: read
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sysvale/cuida",
-	"version": "3.158.2",
+	"version": "3.158.3",
 	"description": "A design system built by Sysvale, using storybook and Vue components",
 	"repository": {
 		"type": "git",

--- a/src/components/BaseInput.vue
+++ b/src/components/BaseInput.vue
@@ -450,6 +450,10 @@ const inputTopPadding = computed(() => {
 	return props.type === 'textarea' ? '8px' : '14px';
 });
 
+const resizeType = computed(() => {
+	return props.type === 'textarea' ? 'vertical' : 'none';
+});
+
 const hasError = computed(() => {
 	return props.state === 'invalid';
 });
@@ -668,7 +672,7 @@ defineExpose({
 		text-align: start;
 		color: tokens.$n-600;
 		width: 100%;
-		resize: vertical;
+		resize: v-bind(resizeType);
 		cursor: v-bind(computedCursor);
 		background-color: transparent;
 		line-height: 1.5;

--- a/src/components/BaseInput.vue
+++ b/src/components/BaseInput.vue
@@ -451,7 +451,9 @@ const inputTopPadding = computed(() => {
 });
 
 const resizeType = computed(() => {
-	return props.type === 'textarea' ? 'vertical' : 'none';
+	return props.type === 'textarea'
+		? 'vertical'
+		: 'none';
 });
 
 const hasError = computed(() => {

--- a/src/components/BaseMobileInput.vue
+++ b/src/components/BaseMobileInput.vue
@@ -532,6 +532,10 @@ const shouldShowLink = computed(() => (
 	&& props.supportLinkUrl.length
 ));
 
+const resizeType = computed(() => {
+	return props.type === 'textarea' ? 'vertical' : 'none';
+});
+
 /* WATCHERS */
 watch(model, (newValue, oldValue) => {
 	if (newValue !== oldValue) {
@@ -694,7 +698,7 @@ defineExpose({
 		text-align: start;
 		color: tokens.$n-700;
 		width: 100%;
-		resize: vertical;
+		resize: v-bind(resizeType);
 		font-size: 14.5px;
 		cursor: v-bind(computedCursor);
 


### PR DESCRIPTION
#### Por favor, verifique se o seu pull request está de acordo com o checklist abaixo:

- [x] A implementação feita possui testes (Caso haja um motivo para não haver testes/haver apenas testes de snapshot, descrever abaixo)
- [x] A documentação no mdx foi feita ou atualizada, caso necessário
- [x] O eslint passou localmente

### 1 - Resumo

- Impede que inputs nativos HTML usados pelos componentes de input do Cuida sejam redimensionados pelo usuário para preservar bom funcionamento (com exceção dos componentes TextArea).

### 2 - Tipo de pull request

- [ ] 🧱 Novo componente
- [ ] ✨ Nova feature ou melhoria
- [x] 🐛 Fix
- [ ] 👨‍💻 Refatoração
- [ ] 📝 Documentação
- [ ] 🎨 Estilo
- [ ] 🤖 Build ou CI/CD


### 3 - Esse PR fecha alguma issue? Favor referenciá-la

### 4 - Quais são os passos para avaliar o pull request?
- Acesse a documentação de produção do Cuida, vá até um dos componentes (o comportamento acontece apenas no Firefox) e verifique que qualquer componente de input que tenha como base o BaseInput (TextInput, NumberInput etc) exibe o indicativo de que é redimensionável pelo usuário;
- Tente redimensionar o componente e veja que é possível fazê-lo;
- Agora, através deste PR, faça o mesmo processo e verifique que só é possível redimensionar o componente TextArea;
- Deixe seu like e se inscreva no canal

### 5 - Imagem ou exemplo de uso:
- Exemplo do comportamento indesejado:

<img width="306" height="114" alt="image" src="https://github.com/user-attachments/assets/9b6ee969-0505-47ec-8f38-6ea6054fd9c9" />


### 6 - Esse pull request adiciona _breaking changes_?
- [ ] Sim
- [x] Não
