### PR TITLE
fix: remove emissão de objeto vazio ao realizar blur

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sysvale/cuida",
-	"version": "3.158.3",
+	"version": "3.158.4",
 	"description": "A design system built by Sysvale, using storybook and Vue components",
 	"repository": {
 		"type": "git",

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -446,7 +446,7 @@ function filterOptions(value) {
 		return;
 	}
 
-	if (props.searchable && props.addable) {
+	if (props.searchable) {
 		searchString.value = value;
 	}
 
@@ -601,11 +601,6 @@ function hide() {
 		localValue.value = null;
 	}
 
-	if (!searchString.value && !shouldClearSelection) {
-		localValue.value = localOptions.value.some(item => item[props.optionsField]?.toLowerCase() === get(localValue.value, props.optionsField)?.toLowerCase())
-			? localValue.value
-			: {};
-	}
 
 	nextTick(() => {
 		localOptions.value = pristineOptions.value;

--- a/src/tests/Select.spec.js
+++ b/src/tests/Select.spec.js
@@ -1,7 +1,7 @@
-import { describe, test, expect } from 'vitest';
 import { mount } from '@vue/test-utils';
-import Select from '../components/Select.vue';
+import { describe, expect, test } from 'vitest';
 import CdsBaseInput from '../components/BaseInput.vue';
+import Select from '../components/Select.vue';
 
 describe('Select', () => {
 	test('renders correctly', () => {
@@ -216,5 +216,26 @@ describe('Select', () => {
 
 		expect(wrapper.emitted('update:modelValue')).toBeUndefined();
 		expect(wrapper.vm.localValue).toEqual({ value: 'Option 1' });
+	});
+
+	test('set modelValue to null when blurred with active filtered search that does not find any items (searchable: true)', async () => {
+		const wrapper = mount(Select, {
+			props: {
+				label: 'label',
+				id: 'select-input',
+				options: [{ value: 'Option 1' }, { value: 'Option 2' }],
+				searchable: true,
+				modelValue: { value: 'Option 1' },
+			},
+		});
+
+		await wrapper.find('input').trigger('focus');
+		await wrapper.find('input').setValue('Not an option');
+		await wrapper.findComponent(CdsBaseInput).trigger('input');
+
+		await wrapper.find('input').trigger('blur');
+
+		expect(wrapper.emitted('update:modelValue')).toStrictEqual([[ null ]]);
+		expect(wrapper.vm.localValue).toBeNull();
 	});
 });

--- a/src/tests/Select.spec.js
+++ b/src/tests/Select.spec.js
@@ -180,4 +180,41 @@ describe('Select', () => {
 		await wrapper.find('input').trigger('blur');
 		expect(wrapper.vm.active).toBe(false);
 	});
+
+	test('does not emit update:modelValue when focused and blurred without changes (when modelValue is empty)', async () => {
+		const wrapper = mount(Select, {
+			props: {
+				label: 'label',
+				id: 'select-input',
+				options: [{ value: 'Option 1' }, { value: 'Option 2' }],
+				modelValue: undefined,
+			},
+		});
+
+		await wrapper.find('input').trigger('focus');
+		await wrapper.find('input').trigger('blur');
+
+		expect(wrapper.emitted('update:modelValue')).toBeUndefined();
+	});
+
+	test('does not reset modelValue when blurred with active filtered search (searchable: true)', async () => {
+		const wrapper = mount(Select, {
+			props: {
+				label: 'label',
+				id: 'select-input',
+				options: [{ value: 'Option 1' }, { value: 'Option 2' }],
+				searchable: true,
+				modelValue: { value: 'Option 1' },
+			},
+		});
+
+		await wrapper.find('input').trigger('focus');
+		await wrapper.find('input').setValue('Option 2');
+		await wrapper.findComponent(CdsBaseInput).trigger('input');
+
+		await wrapper.find('input').trigger('blur');
+
+		expect(wrapper.emitted('update:modelValue')).toBeUndefined();
+		expect(wrapper.vm.localValue).toEqual({ value: 'Option 1' });
+	});
 });


### PR DESCRIPTION
#### Por favor, verifique se o seu pull request está de acordo com o checklist abaixo:

- [x] A implementação feita possui testes (Caso haja um motivo para não haver testes/haver apenas testes de snapshot, descrever abaixo)
- [x] A documentação no mdx foi feita ou atualizada, caso necessário
- [x] O eslint passou localmente

### 1 - Resumo
Ao focar no select (com o mouse ou teclado) e depois desfocar o model era atualizado para um objeto vazio `{}`. Esse comportamento também acontecia quando selecionávamos uma opção, depois pesquisassemos por um item inexistente e desfocasse o input. 

Isso é um problema pois nos nossos formulários o objeto vazio é truthy e, com isso, enviado ao back-end. Caso o usuário foque num select não obrigatório e tente enviar o formulário o back-end enviará um erro de validação ou, se não houver uma validação bem implementada, armazenará o objeto vazio na base.

### 2 - Tipo de pull request

- [ ] 🧱 Novo componente
- [ ] ✨ Nova feature ou melhoria
- [X] 🐛 Fix
- [ ] 👨‍💻 Refatoração
- [ ] 📝 Documentação
- [ ] 🎨 Estilo
- [ ] 🤖 Build ou CI/CD


### 3 - Esse PR fecha alguma issue? Favor referenciá-la
#1095 

### 4 - Quais são os passos para avaliar o pull request?
- Foque no select com o mouse ou teclado e depois desfoque sem selecionar nada; verifique que o evento `update:model-value` não é disparado
- Com o input no modo searchable selecione um item qualquer, depois pesquise por um item inexistente e desfoque sem selecionar nada; verifique que o evento `update:model-value` é disparado com `null`

### 5 - Imagem ou exemplo de uso:
[Gravação de tela de 2026-06-29 10-52-11.webm](https://github.com/user-attachments/assets/a55573f8-3fe7-4fbc-b55e-19887cc02c60)

### 6 - Esse pull request adiciona _breaking changes_?
- [ ] Sim
- [X] Não
