### PR TITLE
feat: adiciona props de placeholder customizáveis no TimeInput

### DIFF
--- a/docs/docgen/PlaygroundBuilder.vue
+++ b/docs/docgen/PlaygroundBuilder.vue
@@ -174,7 +174,7 @@ watch(model, () => {
 				parsedValue = rawValue;
 			}
 
-			if (!isNaN(parsedValue) && !isNaN(parseFloat(parsedValue)) && isFinite(parsedValue)) {
+			if (propData.type.name.includes('number') && !isNaN(parsedValue) && !isNaN(parseFloat(parsedValue)) && isFinite(parsedValue)) {
 				parsedValue = Number(parsedValue);
 			}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sysvale/cuida",
-	"version": "3.159.0",
+	"version": "3.160.0",
 	"description": "A design system built by Sysvale, using storybook and Vue components",
 	"repository": {
 		"type": "git",

--- a/src/components/TimeInput.vue
+++ b/src/components/TimeInput.vue
@@ -34,7 +34,7 @@
 					min="0"
 					max="23"
 					step="1"
-					placeholder="00"
+					:placeholder="hourPlaceholder"
 					@keyup.up="startHour++"
 					@keyup.down="startHour > 0 ? startHour-- : null"
 					@input="handleTimeInput"
@@ -50,7 +50,7 @@
 					min="0"
 					max="59"
 					step="1"
-					placeholder="00"
+					:placeholder="minutePlaceholder"
 					@keyup.up="startMinute++"
 					@keyup.down="startMinute > 0 ? startMinute-- : null"
 					@input="handleTimeInput"
@@ -73,7 +73,7 @@
 					min="0"
 					max="23"
 					step="1"
-					placeholder="00"
+					:placeholder="hourPlaceholder"
 					@keyup.up="endHour++"
 					@keyup.down="endHour > 0 ? endHour-- : null"
 					@input="handleTimeInput"
@@ -89,7 +89,7 @@
 					min="0"
 					max="59"
 					step="1"
-					placeholder="00"
+					:placeholder="minutePlaceholder"
 					@keyup.up="endMinute++"
 					@keyup.down="endMinute > 0 ? endMinute-- : null"
 					@input="handleTimeInput"
@@ -203,6 +203,22 @@ export default {
 		errorMessage: {
 			type: String,
 			default: 'Horário inválido',
+		},
+		/**
+		 * Texto exibido como placeholder nos campos de hora.
+		 * Por padrão, exibe '00'.
+		 */
+		hourPlaceholder: {
+			type: String,
+			default: '00',
+		},
+		/**
+		 * Texto exibido como placeholder nos campos de minuto.
+		 * Por padrão, exibe '00'.
+		 */
+		minutePlaceholder: {
+			type: String,
+			default: '00',
 		},
 	},
 

--- a/src/tests/TimeInput.spec.ts
+++ b/src/tests/TimeInput.spec.ts
@@ -12,5 +12,83 @@ describe('TimeInput', () => {
 
 		expect(wrapper.html()).toMatchSnapshot();
 	});
+
+	test('uses "00" as default placeholder for hour and minute inputs', () => {
+		const wrapper = mount(TimeInput, {
+			props: { label: 'Horário' },
+		});
+
+		const inputs = wrapper.findAll('input');
+		inputs.forEach((input) => {
+			expect(input.attributes('placeholder')).toBe('00');
+		});
+	});
+
+	test('applies custom hourPlaceholder to hour inputs', () => {
+		const wrapper = mount(TimeInput, {
+			props: {
+				label: 'Horário',
+				hourPlaceholder: 'HH',
+			},
+		});
+
+		const hourInputs = wrapper.findAll('input[type="text"]').filter(
+			(_, i) => i % 2 === 0,
+		);
+
+		hourInputs.forEach((input) => {
+			expect(input.attributes('placeholder')).toBe('HH');
+		});
+	});
+
+	test('applies custom minutePlaceholder to minute inputs', () => {
+		const wrapper = mount(TimeInput, {
+			props: {
+				label: 'Horário',
+				minutePlaceholder: 'mm',
+			},
+		});
+
+		const minuteInputs = wrapper.findAll('input[type="text"]').filter(
+			(_, i) => i % 2 !== 0,
+		);
+
+		minuteInputs.forEach((input) => {
+			expect(input.attributes('placeholder')).toBe('mm');
+		});
+	});
+
+	test('supports different placeholders for hour and minute simultaneously', () => {
+		const wrapper = mount(TimeInput, {
+			props: {
+				label: 'Horário',
+				hourPlaceholder: 'HH',
+				minutePlaceholder: 'mm',
+			},
+		});
+
+		const inputs = wrapper.findAll('input[type="text"]');
+
+		expect(inputs[0].attributes('placeholder')).toBe('HH');
+		expect(inputs[1].attributes('placeholder')).toBe('mm');
+	});
+
+	test('applies placeholders to range mode inputs as well', () => {
+		const wrapper = mount(TimeInput, {
+			props: {
+				label: 'Horário',
+				mode: 'range',
+				hourPlaceholder: 'HH',
+				minutePlaceholder: 'mm',
+			},
+		});
+
+		const inputs = wrapper.findAll('input[type="text"]');
+
+		expect(inputs[0].attributes('placeholder')).toBe('HH');
+		expect(inputs[1].attributes('placeholder')).toBe('mm');
+		expect(inputs[2].attributes('placeholder')).toBe('HH');
+		expect(inputs[3].attributes('placeholder')).toBe('mm');
+	});
 });
 


### PR DESCRIPTION
#### Por favor, verifique se o seu pull request está de acordo com o checklist abaixo:

- [x] A implementação feita possui testes (Caso haja um motivo para não haver testes/haver apenas testes de snapshot, descrever abaixo)
- [x] A documentação no mdx foi feita ou atualizada, caso necessário
- [x] O eslint passou localmente

### 1 - Resumo
Adiciona as props `hourPlaceholder` e `minutePlaceholder` no componente `CdsTimeInput`, permitindo definir placeholders separados para os campos de hora e minuto. Ambas são opcionais e possuem valor padrão `"00"`.

Corrige também um bug no `PlaygroundBuilder` onde props string com valor padrão numérico (ex: `"00"`) eram convertidas indevidamente para Number.

### 2 - Tipo de pull request

- [ ] 🧱 Novo componente
- [X] ✨ Nova feature ou melhoria
- [ ] 🐛 Fix
- [ ] 👨‍💻 Refatoração
- [ ] 📝 Documentação
- [ ] 🎨 Estilo
- [ ] 🤖 Build ou CI/CD

### 3 - Esse PR fecha alguma issue? Favor referenciá-la
Não

### 4 - Quais são os passos para avaliar o pull request?
- Execute o comando `npx vitest run src/tests/TimeInput.spec.ts` e garanta que todos os testes passaram com sucesso
- No playground da documentação do TimeInput, valide que os campos de placeholder aparecem como text input (não como select)
- Verifique que o valor padrão dos placeholders é exibido como `"00"` ao invés de `0`
- Teste passando `hour-placeholder="HH"` e `minute-placeholder="mm"` e valide que os placeholders são aplicados corretamente

### 5 - Imagem ou exemplo de uso:
```vue
<CdsTimeInput
  v-model="time"
  label="Horário"
  hour-placeholder="HH"
  minute-placeholder="mm"
/>
```

### 6 - Esse pull request adiciona _breaking changes_?
- [ ] Sim
- [X] Não