### PR TITLE
fix: adiciona fallback de fonte Satoshi nos inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sysvale/cuida",
-	"version": "3.160.0",
+	"version": "3.160.1",
 	"description": "A design system built by Sysvale, using storybook and Vue components",
 	"repository": {
 		"type": "git",

--- a/src/assets/sass/placeholders.scss
+++ b/src/assets/sass/placeholders.scss
@@ -10,11 +10,11 @@
 	margin: 2px;
 
 	input {
-		font-family: 'Satoshi';
+		font-family: Satoshi, Inter, Avenir, Helvetica, Arial, sans-serif;
 	}
 
 	textarea {
-		font-family: 'Satoshi';
+		font-family: Satoshi, Inter, Avenir, Helvetica, Arial, sans-serif;
 	}
 }
 

--- a/src/components/FilterSelect.vue
+++ b/src/components/FilterSelect.vue
@@ -443,7 +443,7 @@ export default {
 		}
 
 		input {
-			font-family: 'Satoshi';
+			font-family: Satoshi, Inter, Avenir, Helvetica, Arial, sans-serif;
 		}
 	}
 

--- a/src/components/InlineDateInput.vue
+++ b/src/components/InlineDateInput.vue
@@ -375,7 +375,7 @@ export default {
 		align-items: center;
 
 		input {
-			font-family: 'Satoshi';
+			font-family: Satoshi, Inter, Avenir, Helvetica, Arial, sans-serif;
 		}
 	}
 

--- a/src/components/MobileStepperInput.vue
+++ b/src/components/MobileStepperInput.vue
@@ -112,7 +112,7 @@ watch(model, (newValue) => {
 		gap: tokens.spacer(2);
 
 		input {
-			font-family: 'Satoshi';
+			font-family: Satoshi, Inter, Avenir, Helvetica, Arial, sans-serif;
 		}
 	}
 

--- a/src/components/PasswordInput.vue
+++ b/src/components/PasswordInput.vue
@@ -280,7 +280,7 @@ export default {
 	background: tokens.$n-0;
 
 	input {
-		font-family: 'Satoshi';
+		font-family: Satoshi, Inter, Avenir, Helvetica, Arial, sans-serif;
 	}
 
 	&--fluid {

--- a/src/components/TimeInput.vue
+++ b/src/components/TimeInput.vue
@@ -381,7 +381,7 @@ export default {
 		align-items: center;
 
 		input {
-			font-family: 'Satoshi';
+			font-family: Satoshi, Inter, Avenir, Helvetica, Arial, sans-serif;
 		}
 	}
 


### PR DESCRIPTION
## O que mudou

- Adiciona fallback de fonte (`Inter, Avenir, Helvetica, Arial, sans-serif`) para o `font-family: Satoshi` em todos os inputs de entrada de texto
- O fallback garante que, caso a fonte Satoshi não esteja disponível, os elementos de input continuem legíveis com fontes do sistema

## Arquivos alterados

- `src/assets/sass/placeholders.scss` — fallback em `input` e `textarea` do placeholder base
- `src/components/FilterSelect.vue`
- `src/components/InlineDateInput.vue`
- `src/components/MobileStepperInput.vue`
- `src/components/PasswordInput.vue`
- `src/components/TimeInput.vue`

## Por quê

Quando a fonte Satoshi não é carregada corretamente (problemas de CDN, bloqueio de CORS, etc.), os campos de input ficavam sem fonte definida — resultando em fallback inesperado do browser. Com a cadeia de fallback explícita, a experiência visual permanece consistente mesmo sem a fonte primária.