### PR TITLE
fix(multiselect): corrige emissão do valor 'on' ao clicar no checkbox

### DIFF
--- a/docs/.docgen/components-metadata.json
+++ b/docs/.docgen/components-metadata.json
@@ -2482,6 +2482,12 @@
         }
       }
     ],
+    "slots": [
+      {
+        "name": "append",
+        "description": "Slot para renderizar elementos adicionais à direita da etiqueta do checkbox."
+      }
+    ],
     "sourceFiles": [
       "src/components/Checkbox.vue"
     ]
@@ -2604,6 +2610,19 @@
     "events": [
       {
         "name": "update:modelValue"
+      }
+    ],
+    "slots": [
+      {
+        "name": "append",
+        "scoped": true,
+        "description": "Slot com escopo para renderizar elementos adicionais à direita de cada checkbox do grupo.",
+        "bindings": [
+          {
+            "name": "option",
+            "title": "binding"
+          }
+        ]
       }
     ],
     "sourceFiles": [
@@ -13845,6 +13864,28 @@
         "defaultValue": {
           "func": false,
           "value": "'Horário inválido'"
+        }
+      },
+      {
+        "name": "hourPlaceholder",
+        "description": "Texto exibido como placeholder nos campos de hora.\nPor padrão, exibe '00'.",
+        "type": {
+          "name": "string"
+        },
+        "defaultValue": {
+          "func": false,
+          "value": "'00'"
+        }
+      },
+      {
+        "name": "minutePlaceholder",
+        "description": "Texto exibido como placeholder nos campos de minuto.\nPor padrão, exibe '00'.",
+        "type": {
+          "name": "string"
+        },
+        "defaultValue": {
+          "func": false,
+          "value": "'00'"
         }
       }
     ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sysvale/cuida",
-	"version": "3.160.1",
+	"version": "3.160.2",
 	"description": "A design system built by Sysvale, using storybook and Vue components",
 	"repository": {
 		"type": "git",

--- a/src/components/Multiselect.vue
+++ b/src/components/Multiselect.vue
@@ -109,16 +109,15 @@
 					<div class="option__checkbox">
 						<input
 							:id="`input-${option[optionsField]}-${uniqueKey}`"
-							v-model="option.isSelected"
+							:checked="option.isSelected"
 							type="checkbox"
 							:name="`input-${option[optionsField]}-${uniqueKey}`"
-							:value="true"
+							@click.stop.prevent
 						>
 						<label
 							:id="`checkbox-${option[optionsField]}`"
 							:for="`input-${option[optionsField]}-${uniqueKey}`"
 							:class="option.isSelected ? `option__checkbox--${variant}` : ''"
-							@click="addItemViaCustomCheckbox(option)"
 						/>
 					</div>
 					<slot
@@ -480,14 +479,6 @@ export default {
 					}));
 				}
 			});
-		},
-
-		addItemViaCustomCheckbox(option) {
-			option.isSelected = !option.isSelected;
-			this.selectedValue = [
-				...this.selectedValue,
-				option,
-			];
 		},
 
 		handleClose() {


### PR DESCRIPTION
#### Por favor, verifique se o seu pull request está de acordo com o checklist abaixo:

- [x] A implementação feita possui testes (Caso haja um motivo para não haver testes/haver apenas testes de snapshot, descrever abaixo)
- [x] A documentação no mdx foi feita ou atualizada, caso necessário
- [x] O eslint passou localmente

### 1 - Resumo
- Corrige a seleção de opções no Multiselect ao clicar no checkbox visual.
  - Antes, ao clicar no checkbox de uma opção, o componente emitia o valor "on" em vez do objeto da opção selecionada.
  - Agora, o checkbox emite corretamente o objeto da opção, tanto na seleção quanto na deseleção.
  - O comportamento do clique no texto da opção permanece inalterado.

### 2 - Tipo de pull request

- [ ] 🧱 Novo componente
- [ ] ✨ Nova feature ou melhoria
- [x] 🐛 Fix
- [ ] 👨‍💻 Refatoração
- [ ] 📝 Documentação
- [ ] 🎨 Estilo
- [ ] 🤖 Build ou CI/CD


### 3 - Esse PR fecha alguma issue? Favor referenciá-la

### 4 - Quais são os passos para avaliar o pull request?
- Abra um Multiselect com opções disponíveis.
- Clique no checkbox visual de uma opção e verifique que o objeto da opção é emitido (não o valor "on").
- Clique no checkbox novamente e verifique que a opção é removida.
- Clique no texto da opção e confirme que a seleção continua funcionando como antes.
- Verifique que o checkmark visual acompanha o estado selecionado/deselecionado.
### 5 - Imagem ou exemplo de uso:

### 6 - Esse pull request adiciona _breaking changes_?
- [ ] Sim
- [ ] Não
